### PR TITLE
Syntax evolution on dated variables and formulas

### DIFF
--- a/coding-the-legislation/10_basic_example.md
+++ b/coding-the-legislation/10_basic_example.md
@@ -11,7 +11,7 @@ class flat_tax_on_salary(Variable):
     label = u"Individualized and monthly paid tax on salaries"
     definition_period = MONTH
 
-    def function(person, period):
+    def formula(person, period):
         salary = person('salary', period)
 
         return salary * 0.25
@@ -34,7 +34,7 @@ Let's explain in details the different part of the code:
   - `label = u"Individualized..."` gives, in a human-readable language, concise information about the variable.
   - `definition_period = MONTH` states that the variable will be computed on months.
 - Formula:
-  - `def function(person, period):` declares the formula that will be used to calculate the `flat_tax_on_salary` for a given `person` at a given `period`. Because `definition_period = MONTH`, `period` is constrained to be a month.
+  - `def formula(person, period):` declares the formula that will be used to calculate the `flat_tax_on_salary` for a given `person` at a given `period`. Because `definition_period = MONTH`, `period` is constrained to be a month.
   - `salary = person('salary', period)` calculates the salary of the person, for the given month. This will, of course, work only if `salary` is another variable in the tax and benefit system.
   - `return salary * 0.25` returns the result for the given period.
 
@@ -72,7 +72,7 @@ class flat_tax_on_salary(Variable):
     label = u"Individualized and monthly paid tax on salaries"
     definition_period = MONTH
 
-    def function(person, period, legislation):
+    def formula(person, period, legislation):
         salary = person('salary', period)
 
         return salary * legislation(period).taxes.salary.rate

--- a/coding-the-legislation/25_vectorial_computing.md
+++ b/coding-the-legislation/25_vectorial_computing.md
@@ -8,7 +8,7 @@ This enables fast calculations for a big population, but comes with some constra
 Each computation in OpenFisca returns a **vector**. For instance, for a simulation containing 3 persons whose ages are 45, 42, and 41, executing the following formula:
 
 ```py
-def function(person, period):
+def formula(person, period):
     age = person('age', period)
     print(age)     
 ```

--- a/coding-the-legislation/30_case_disjunction.md
+++ b/coding-the-legislation/30_case_disjunction.md
@@ -2,11 +2,12 @@
 
 ## Limitations
 
-Built-in python conditionnal structures are not compatible with [vector calculus](25_vectorial_computing.md).  The following formula would for instance **break**:
+Built-in python conditionnal structures are not compatible with [vector calculus](25_vectorial_computing.md).  
+The following formula would for instance **break**:
 
 ```py
 # THIS IS NOT A VALID OPENFISCA FORMULA
-def function(person, period):
+def formula(person, period):
     salary = person('salary', period)
     if salary < 1000:
         return 200
@@ -21,12 +22,13 @@ Some solutions though exist to emulate these structures.
 Applying a condition is in many cases equivalent to a simple multiplication. For instance, our previous example can be rewritten:
 
 ```py
-def function(person, period):
+def formula(person, period):
     condition_salary = person('salary', period) < 1000
     return condition_salary * 200
 ```
 
-For a person, if  `condition_salary` is `True` (equivalent to `1` in logical algebra), the returned result will be `200`. However, if `condition_salary` is `False` (equivalent to `0`), the returned result will be `0`.
+For a person, if  `condition_salary` is `True` (equivalent to `1` in logical algebra), the returned result will be `200`. 
+However, if `condition_salary` is `False` (equivalent to `0`), the returned result will be `0`.
 
 ## Ternary condition
  
@@ -35,7 +37,7 @@ Let's now write a formula that still returns `200` if the person salary is lower
 The helper function `where` offers a simple syntax to handle these cases.
 
 ```py
-def function(person, period):
+def formula(person, period):
     condition_salary = person('salary', period) < 1000
     return where(condition_salary, 200, 100)
 ```
@@ -53,7 +55,7 @@ Let's consider a more complex case, where we want to attribute to a person:
 We can use the helper function `select` to implement this behaviour:
 
 ```py
-def function(person, period):
+def formula(person, period):
     salary = person('salary', period)
     return select(
         [salary <= 500, salary <= 1000, salary <= 1500, salary > 1500],
@@ -69,10 +71,10 @@ If the first condition is met, the first value will be returned, without conside
 
 If the first condition is not met, then only the second condition will be considered.
 
-If no condition is met, `0` will be returned. The previous function is thus strictly equivalent to:
+If no condition is met, `0` will be returned. The previous formula is thus strictly equivalent to:
 
 ```py
-def function(person, period):
+def formula(person, period):
     salary = person('salary', period)
     return select(
         [salary <= 500, salary <= 1000, salary <= 1500],
@@ -89,7 +91,7 @@ For instance, let's consider that a person will be granted `200` if either:
     - They are in a situation of handicap
 
  ```py
-def function(person, period):
+def formula(person, period):
     condition_age = person('age') >= 25
     condition_salary = person('salary', period) < 1000
     condition_handicap = person('handicap')

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -16,14 +16,14 @@ class salary(Variable):
     label = u"Salary for a month"
     definition_period = MONTH
 
-    def function(person, period):
+    def formula(person, period):
         ...
 ```
 
 The size of the period is constrained by the class attribute `definition_period`:
-  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `function` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a period that is not a month will raise an error before entering `function`.
-  - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `function` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
-  - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `function`. However when `function` is executed, the parameter `period` can be anything and it should not be used.
+  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a period that is not a month will raise an error before entering `formula`.
+  - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `formula` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
+  - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `formula`. However when `formula` is executed, the parameter `period` can be anything and it should not be used.
 
 
 ## Calculating dependencies for a period different than the one they are defined for
@@ -37,7 +37,7 @@ class taxes(Variable):
     label = u"Taxes for a whole year"
     definition_period = YEAR
 
-    def function(person, period):  # period is a year because definition_period = YEAR
+    def formula(person, period):  # period is a year because definition_period = YEAR
         salary_past_year = person('salary', period)  # salary is computed on a year while it's a montly variable, openfisca will complain
         ...
 ```
@@ -53,7 +53,7 @@ class taxes(Variable):
     label = u"Taxes for a whole year"
     definition_period = YEAR
 
-    def function(person, period):  # period is a year because definition_period = YEAR
+    def formula(person, period):  # period is a year because definition_period = YEAR
         salary_last_year = person('salary', period, options = [ADD])
         ...
 ```
@@ -67,7 +67,7 @@ class salary_net_of_taxes(Variable):
     label = u"Monthly salary, net of taxes"
     definition_period = MONTH
 
-    def function(person, period):  # period is a month because definition_period = MONTH
+    def formula(person, period):  # period is a month because definition_period = MONTH
         # The variable taxes is computed on a year, monthly_taxes equals the 12th of that result
         monthly_taxes = person('taxes', period, options = [DIVIDE])
 
@@ -91,7 +91,7 @@ class unemployment_benefit(Variable):
     label = u"Unemployment benefit"
     definition_period = MONTH
 
-    def function(person, period):
+    def formula(person, period):
         salary_last_3_months = person('salary', period.last_3_month)
         salary_last_year = person('salary', period.last_year)
 
@@ -139,7 +139,7 @@ class salary(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def function(person, period):
+    def formula(person, period):
         ...
 ```
 

--- a/coding-the-legislation/40_legislation_evolutions.md
+++ b/coding-the-legislation/40_legislation_evolutions.md
@@ -28,9 +28,9 @@ class flat_tax_on_salary(Variable):
 <NODE code="taxes">
     <NODE code='salary'>
       <CODE code="rate" description="Rate for the flat tax on salaries">
-        <VALUE deb="2016-01-01" fuzzy="true" valeur="0.25" />
-        <VALUE deb="2015-01-01" fin="2015-12-31" valeur="0.20" />
-        <VALUE deb="2014-01-01" fin="2014-12-31" valeur="0.22" />
+        <VALUE deb="2016-01-01" valeur="0.25" />
+        <VALUE deb="2015-01-01" valeur="0.20" />
+        <VALUE deb="2014-01-01" valeur="0.22" />
       </CODE>
     </NODE>
 </NODE>

--- a/coding-the-legislation/40_legislation_evolutions.md
+++ b/coding-the-legislation/40_legislation_evolutions.md
@@ -43,7 +43,8 @@ For the following inputs:
     salary:
         2016-01: 2000
         2015-12: 2000
-        2015-11: 2000
+        2015-01: 2000
+        2014-12: 2000
         2014-01: 2000
 ```
 
@@ -52,49 +53,20 @@ we get the output:
     flat_tax_on_salary:
         2016-01: 500
         2015-12: 400
-        ...
         2015-01: 400
         2014-12: 440
-        ...
         2014-01: 440
 ```
 
 [Read more about how to code parameters](./legislation_parameters.md#parameters-and-time).
 
-## Variable defined until a specific date
-
-As the legislation evolves, some fiscal or benefit mechanism appear and disapear.  
-For every variable, you can specify the attribute `end`; it defines until when this variable makes sense.
-
-If called outside of its definition time, a variable will **not** execute its formula and instead **return its default value**.
-
-For instance:
-```py
-class flat_tax_on_salary(Variable):
-    column = FloatCol
-    entity = Person
-    label = u"Individualized and monthly paid tax on salaries"
-    end = '2014-12-31'
-    definition_period = MONTH
-
-    def formula(person, period, legislation):
-        ...
-```
-
-will return a value calculated by its `formula` function if it is called for any date before its `end = '2014-12-31'` date. 
-While it will return the default OpenFisca value for `FloatCol` if it is called after its `end` date.
-
-Note that:
-- The `end` is the last day a variable and its formulas are valid (not the first day of unvalidity).
-- The `end` value is a string of 'YYYY-MM-DD' format where YYYY, MM and DD are respectively a year, month and day.
-- When defining a date, the month is given **before** the day.
-
 ## Formula evolving over time
 
 Some fiscal or benefit mechanism significantly evolve over time, with bigger changes than a simple parameter adjustement.
 
-For instance, let's assume that from the 1st of Jan. 2017, our previous `flat_tax_on_salary` will not apply on the first `1000` earned by the person. 
-We can implement this rule with dated formulas:
+For instance, let's assume that from the 1st of Jan. 2017, our previous `flat_tax_on_salary` will not be applied on the first `1000` earned by the person.
+
+We implement this rule by adding a new formula to our variable, and _dating_ it:
 
 ```py
 class flat_tax_on_salary(Variable):
@@ -108,24 +80,84 @@ class flat_tax_on_salary(Variable):
         salary_above_1000 = min_(salary - 1000, 0)
         return salary_above_1000 * legislation(period).taxes.salary.rate
 
-    def formula_2014(self, simulation, period):
-        salary = person('salary', period)
-        salary_above_1000 = min_(salary - 1000, 0)
-        return salary_above_750 * legislation(period).taxes.salary.rate
-
     def formula(self, simulation, period):
         salary = person('salary', period)
 
         return salary * legislation(period).taxes.salary.rate
 ```
 
+If the `flat_tax_on_salary` is calculated for a person **before** the 31st of Dec. 2016 (included), `formula` is used. If it is called **after** the 1st of Jan 2017 (included), `formula_2017` is used.
+
 Note that:
-- A formula name should start with `formula`.
-- To define a starting date on a formula, we add a suffix to its name: `formula_2017` is valid from '2017'.
-- When no month or day is specified, OpenFisca uses '01' as default value: `formula_2017` is similar to `formula_2017_01_01`.
-- OpenFisca sets '0001-01-01' as default starting date for formulas without date: `formula` is similar to `formula_0001_01_01`.
-- The end of validity of a formula is deduced from its siblings: 
-  * the last day of validity for `formula` is '2013-12-31',
-  * the last day of validity for `formula_2014` is '2016-12-31'.
-- When there is an `end` attribute, every formula stops on the defined `end` day. 
-If called outside of its definition time, a variable will **not** execute its formula and instead **return its default value**.
+- A formula name must always start with `formula`.
+- To define a starting date for a formula, we add to its name a suffix made of an underscore followed by a date.
+  - For instance, `formula_2017_01_01` is active from the 1st of Jan. 2017.
+- When defining a date, the month is given **before** the day.
+- When no month or day is specified, OpenFisca uses '01' as default value.
+  - For instance, `formula_2017` is equivalent to `formula_2017_01_01`.
+- If no date is specified for a formula, OpenFisca will consider that this formula has been active since the dawn of time (or more precisely, since `0001-01-01`, as Python does not handle B.C. dates).
+  - For instance, `formula` is active on `2010`.
+- A formula is active until another formula, starting later, becomes active and replaces it.
+  - For instance, `formula` is active until `2016-12-31` (included). On the day after, `2017-01-01`, `formula_2017` becomes active, and `formula` becomes inactive.
+
+
+## Introduction of a formula
+
+In our previous example, we assumed that `flat_tax_on_salary` had _always_ had a formula, since the dawn of time. This is a reasonable hypothesis if we are only interested in running computations for recent years.
+
+But most fiscal and benefit mechanisms have been introduced at some point. Let's for instance assume that our `flat_tax_on_salary` only appeared in our legislation on the 1st of June 2005. 
+
+This is easily implemented by _dating_ the two formulas:
+
+```py
+class flat_tax_on_salary(Variable):
+    column = FloatCol
+    entity = Person
+    label = u"Individualized and monthly paid tax on salaries"
+    definition_period = MONTH
+
+    def formula_2017(self, simulation, period):
+        salary = person('salary', period)
+        salary_above_1000 = min_(salary - 1000, 0)
+        return salary_above_1000 * legislation(period).taxes.salary.rate
+
+    def formula_2005_06(self, simulation, period):
+        salary = person('salary', period)
+
+        return salary * legislation(period).taxes.salary.rate
+```
+
+Only a few characters changed in comparison with the last example: the suffix `_2005_06` has been added to the second formula name.
+
+Note that if `flat_tax_on_salary` is calculated **before** `2005-05-31` (included), _none_ of the two formulas is used, as they are _both inactive_ at this time. Instead, **the variable [default value](../variables.md#default-values) is returned**.
+
+
+## Variable defined until a specific date
+
+As the legislation evolves, some fiscal or benefit mechanisms disapear.
+
+Let's for instance assume that a `progressive_income_tax` used to exist before the `flat_tax_on_salary` was introduced, and that therefore this progressive tax disapeared on the 1st of June 2005.
+
+This is implemented with an `end` attribute that define the _last day_ a variable can be calculated:
+
+```py
+class progressive_income_tax(Variable):
+    column = FloatCol
+    entity = Person
+    label = u"Former tax replaced by the flat tax on the 1st of June 2005"
+    definition_period = MONTH
+    end = '2005-05-31'
+
+    def formula(person, period, legislation):
+        # Apply a marginal scale to the person's income
+        ...
+```
+
+If `progressive_income_tax` is called **before** `2005-05-31`(included), `formula` will be used.
+
+However, if `progressive_income_tax` is calculated **after** `2005-06-01` (included), `formula` is **not** used, as it is not active anymore at this time. Instead, **the variable [default value](../variables.md#default-values) is returned**. 
+
+Note that:
+- The `end` day is **inclusive**: it is the last day a variable and its formulas are active (and not the first day it is not active anymore).
+- The `end` value is a string of format `YYYY-MM-DD` where `YYYY`, `MM` and `DD` are respectively a year, month and day.
+- When defining a date, the month is given **before** the day.

--- a/coding-the-legislation/40_legislation_evolutions.md
+++ b/coding-the-legislation/40_legislation_evolutions.md
@@ -1,6 +1,6 @@
 # Legislation evolutions
 
-Openfisca handles the fact that the legislation changes over time.
+Openfisca handles legislation changes over time.
 
 ## Parameter evolution
 
@@ -22,7 +22,7 @@ class flat_tax_on_salary(Variable):
         return salary * legislation(period).taxes.salary.rate
 ```
 
- and let's assume we have in one of our parameter files the value of the rate for the past couple of years:
+and let's assume we have in one of our parameter files the value of the rate for the past couple of years:
 
 ```xml
 <NODE code="taxes">
@@ -60,11 +60,11 @@ we get the output:
 
 [Read more about how to code parameters](./legislation_parameters.md#parameters-and-time).
 
-## Formula evolving over time
+## Formula evolution
 
-Some fiscal or benefit mechanism significantly evolve over time, with bigger changes than a simple parameter adjustement.
+Some fiscal or benefit mechanism significantly evolve over time and call for a change in the formula that computes them. In this case, a simple parameter adjustement is not enough.
 
-For instance, let's assume that from the 1st of Jan. 2017, our previous `flat_tax_on_salary` will not be applied on the first `1000` earned by the person.
+For instance, let's assume that from the 1st of Jan. 2017, the `flat_tax_on_salary` is not applied anymore on the first `1000` earned by a person.
 
 We implement this rule by adding a new formula to our variable, and _dating_ it:
 
@@ -88,7 +88,7 @@ class flat_tax_on_salary(Variable):
 
 If the `flat_tax_on_salary` is calculated for a person **before** the 31st of Dec. 2016 (included), `formula` is used. If it is called **after** the 1st of Jan 2017 (included), `formula_2017` is used.
 
-Note that:
+Formula naming rules:
 - A formula name must always start with `formula`.
 - To define a starting date for a formula, we add to its name a suffix made of an underscore followed by a date.
   - For instance, `formula_2017_01_01` is active from the 1st of Jan. 2017.
@@ -97,11 +97,11 @@ Note that:
   - For instance, `formula_2017` is equivalent to `formula_2017_01_01`.
 - If no date is specified for a formula, OpenFisca will consider that this formula has been active since the dawn of time (or more precisely, since `0001-01-01`, as Python does not handle B.C. dates).
   - For instance, `formula` is active on `2010`.
-- A formula is active until another formula, starting later, becomes active and replaces it.
+- A formula is active until another formula, starting later, becomes active and replaces it (or until the variable `end` date is reached, as we'll see further down in the [Variable end](#variable-end) section).
   - For instance, `formula` is active until `2016-12-31` (included). On the day after, `2017-01-01`, `formula_2017` becomes active, and `formula` becomes inactive.
 
 
-## Introduction of a formula
+## Formula introduction
 
 In our previous example, we assumed that `flat_tax_on_salary` had _always_ had a formula, since the dawn of time. This is a reasonable hypothesis if we are only interested in running computations for recent years.
 
@@ -132,11 +132,11 @@ Only a few characters changed in comparison with the last example: the suffix `_
 Note that if `flat_tax_on_salary` is calculated **before** `2005-05-31` (included), _none_ of the two formulas is used, as they are _both inactive_ at this time. Instead, **the variable [default value](../variables.md#default-values) is returned**.
 
 
-## Variable defined until a specific date
+## Variable end
 
 As the legislation evolves, some fiscal or benefit mechanisms disapear.
 
-Let's for instance assume that a `progressive_income_tax` used to exist before the `flat_tax_on_salary` was introduced, and that therefore this progressive tax disapeared on the 1st of June 2005.
+Let's for instance assume that a `progressive_income_tax` used to exist before the `flat_tax_on_salary` was introduced. This progressive tax then disapeared on the 1st of June 2005.
 
 This is implemented with an `end` attribute that define the _last day_ a variable can be calculated:
 

--- a/coding-the-legislation/50_entities.md
+++ b/coding-the-legislation/50_entities.md
@@ -11,7 +11,7 @@ However, I may for instance:
 You can get the number of person with a given role in an entity with the `nb_persons(role)` method. If no role is given, it will return the numbers of people in the entity.
 
 ```py
-    def function(household, period):
+    def formula(household, period):
         nb_persons = household.nb_persons()
         nb_adults = household.nb_persons(Household.ADULT)
         nb_children = household.nb_persons(Household.CHILD)
@@ -24,7 +24,7 @@ Note that roles are constants that can be accessed from their entity with the no
 You can know whether a person has a certain role with the `has_role(role)` method:
 
 ```py
-    def function(person, period):
+    def formula(person, period):
         is_adult = person.has_role(Household.ADULT)
         is_child = person.has_role(Household.CHILD)
 ```
@@ -49,7 +49,7 @@ class basic_income(Variable):
     label = u"Basic income paid to households"
     definition_period = MONTH
 
-    def function(household, period):
+    def formula(household, period):
         nb_adults = household.nb_persons(Household.ADULT)
         nb_children = household.nb_persons(Household.CHILD)
         salaries = household.members('salary', period)
@@ -74,7 +74,7 @@ class college_scholarship(Variable):
     label = u"College Scholarship for basic income recipients."
     definition_period = MONTH
 
-    def function(person, period):
+    def formula(person, period):
         is_student = person('is_student', period)
         has_household_basic_income = person.household('basic_income', period) > 0
                 
@@ -86,7 +86,7 @@ Similarly, `entity.unique_role('variable_name', period)` allows you to get the v
 For instance, let's assume `Household` has two unique roles, `main_declarant` and `partner`.
 
 ```py
-def function(household, period):
+def formula(household, period):
     household.main_declarant('salary', period) # main declarant's salary
     household.partner('salary', period) # partner's salary
 ```

--- a/coding-the-legislation/inferences.md
+++ b/coding-the-legislation/inferences.md
@@ -2,7 +2,6 @@
 
 Here are the places in which inferences take place in OpenFisca:
 
-- In parameters values, through the `fuzzy` attribute, which artificially extends the validity period of a value.
 - In period management, through `calculate_output`, which can automatically sum or divide values over periods to match the requested period.
 - In period management, through `set_input`, which can automatically sum or divide input values over periods to match the computable period.
 - In some formulas, through `base_function`, which can yield values that the original requested formula could not compute on its own.
@@ -12,12 +11,6 @@ These inferences are not considered good practice, as they tend to make computat
 
 
 ## Known issues
-
-### With `fuzzy`
-
-This parameter introduces a major production risk: if the end date of a parameter used in a computation is reached, and `fuzzy` is not used, then the program will crash
-
-The advised workaround is to _always_ add the `fuzzy` parameter to the last known value.
 
 ### With `base_function`
 

--- a/coding-the-legislation/reforms.md
+++ b/coding-the-legislation/reforms.md
@@ -14,7 +14,7 @@ class income_tax(Variable):
     entity = Household
     label = u'Alternative formula to calculate the income tax, under experimentation'
 
-    def function(household, period):
+    def formula(household, period):
         # (...)
 
 class income_tax_reform(Reform):


### PR DESCRIPTION
Fixes #82 

Updates function names to formula
Explains variable `end` attribute usage
Explains formula starting date usage
Cleans outdated syntax

-----

EDIT by @fpagnoux: Replace Connected by Fixes