### PR TITLE
Publish a PDF offline version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![OpenFisca logo](https://www.openfisca.fr/hotlinks/logo-openfisca.svg)](https://www.openfisca.fr/)
-> Download an [offline version](https://www.gitbook.com/book/openfisca/documentation) of the documentation (direct link to [PDF](https://www.gitbook.com/download/pdf/book/openfisca/documentation), [ePub](https://www.gitbook.com/download/epub/book/openfisca/documentation) and [Mobi](https://www.gitbook.com/download/mobi/book/openfisca/documentation)).
+
+> Download a [PDF offline version](./openfisca-doc.pdf) of this documentation.
 
 # Introduction
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+dependencies:
+  override:
+    - npm install
+    - sudo apt-get update
+    - sudo apt-get install calibre
+
 deployment:
   production:
     branch: master

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   },
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "gitbook build",
+    "build": "gitbook build && gitbook pdf . ./_book/openfisca-doc.pdf",
     "clean": "del _book",
     "postinstall": "gitbook install",
     "start": "gitbook serve --port 2050",
-    "test": "! (npm run build | grep 'warn:')"
+    "test": "! (npm run build | grep 'warn:' | grep -v openfisca-doc.pdf)"
   },
   "engines" : {
     "node" : ">=0.12 <7"
@@ -21,6 +21,7 @@
   "devDependencies": {
     "del-cli": "^0.2.1",
     "gitbook-cli": "^2.3.0",
-    "gh-pages": "^1.0.0"
+    "gh-pages": "^1.0.0",
+    "svgexport": "0.3.2"
   }
 }


### PR DESCRIPTION
Fixes #84

Tested on circle. Harder to run on macOS, as we seem to need to install [Calibre](https://calibre-ebook.com/).