### PR TITLE
"Edit this page" link yields a 404 error

### DIFF
--- a/book.json
+++ b/book.json
@@ -16,7 +16,7 @@
             "url": "https://github.com/openfisca/openfisca-doc"
         },
         "edit-link": {
-            "base": "https://github.com/openfisca/openfisca-doc",
+            "base": "https://github.com/openfisca/openfisca-doc/edit/master",
             "label": "Edit This Page"
         }
     }


### PR DESCRIPTION
Fixes #99 

#### Bug Fix
Fix 404 error on page edition link

> On `openfisca-doc`, update `master` branch settings:
> * Activate `Require branches to be up to date before merging`
> * Activate `Restrict who can push to this branch`
> * Activate `Include administrators`