### PR TITLE
Update the URL for Simulateur de coût d'embauche

### DIFF
--- a/community.md
+++ b/community.md
@@ -48,7 +48,7 @@ The OpenFisca project publishes several softwares built around the simulator whi
 ### Applications
 
 - https://mes-aides.gouv.fr/
-- https://embauche.sgmap.fr/
+- https://embauche.beta.gouv.fr/
 
 ## Presentation slides
 


### PR DESCRIPTION
Fixes #97 
Simulateur de coût d'embauche is now on a beta.gouv.fr url.