### PR TITLE
Correction of an instruction in fancy indexing

### DIFF
--- a/coding-the-legislation/legislation_parameters.md
+++ b/coding-the-legislation/legislation_parameters.md
@@ -154,7 +154,7 @@ zone_1:
     values:
       2015-01-01:
         value: 250
-  single:
+  per_child:
     description: "Amount of housing benefit per child, in zone 1"
     values:
       2015-01-01:


### PR DESCRIPTION
Fields of fancy indexing has to be homogeneous, so i'll change the field `single` which is a duplicate with `per_child`.