### PR TITLE
Improve period documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,7 +14,7 @@
    * [Coding a formula: basic example](coding-the-legislation/10_basic_example.md)
    * [Introducing an input variable](coding-the-legislation/20_input_variables.md)
    * [Vectorial computing](coding-the-legislation/25_vectorial_computing.md)
-   * [Periods](coding-the-legislation/35_periods.md)
+   * [Periods and instants](coding-the-legislation/35_periods.md)
    * [Legislation evolutions](coding-the-legislation/40_legislation_evolutions.md)
    * [Entities](coding-the-legislation/50_entities.md)
    * [Reforms](coding-the-legislation/reforms.md)

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -5,10 +5,6 @@ The smallest unit for OpenFisca periods is the **month**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a month.
-- To manipulate periods (e.g. create a new period), you will need to import the `periods` module like this :
-```py
-from openfisca_core import periods
-```
 
 An Instant is a specific day, such as a cutoff date.
 
@@ -191,28 +187,3 @@ class salary(Variable):
 ```
 
 We can now provide an input for `2015` for `salary`: no error will be raised, and the value will be automatically split between the 12 months of `2015`.
-
-## How to use Instants to represent cutoff dates.
-
-Sometimes, some results depend on a value calculted at a specific date.
-Instants can be used to calculate the value of a parameter or a variable at such date, for example, a scholarship that is awarded only if the student is yonger than 25 on july first of the same year:
-
-```py
-from openfisca_core.periods import Instant
-
-class eligible_for_scholarship(Variable):
-    value_type = bool
-    entity = Person
-    definition_period = YEAR
-
-    def formula(person, period, parameters):
-        july_first = Instant(
-            (period.start.year, 7, 1)
-        ).period('month')
-
-        age_condition = person('age', july_first) <= 25
-
-        return age_condition    
-```
-
-

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -1,13 +1,49 @@
-# Periods
+# Periods and instants
 
-A period can be a month, a year, `n` successive months, `n` successive years or the eternity.
+A Period can be a month, a year, `n` successive months, `n` successive years or the eternity.
+The smallest unit for OpenFisca Periods is the **month**. Therefore:
+
+- All Periods are presumed to start on the first day of their first month.
+- A Period cannot be smaller than a month.
 
 
-## Periods for variable
+An Instant is a specific day, such as a cutoff date.
 
-Most of the quantities calculated in openfisca can change over time. Therefore, each formula calculates a variable for a person (or a family, etc.) **for a given period**.
+> Internally, time, Periods are stored as:
+> - a start instant
+> - a unit (MONTH, YEAR)
+> - a quantity of units.
 
-This period is always the second argument of the formulas:
+## Periods in simulations
+
+In OpenFisca, Periods are encoded in strings. All the valid Period formats are referenced in this table:
+
+| Period format     | Period type     | Example             | Represents                                       | Disambiguation                                                        |
+|-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
+| `AAAA`            | Calendar year   | `'2010'`            | The year 2010.                                   | From the 1st of January 2010 to the 31st of December 2010, inclusive. |
+| `AAAA-MM`         | Month           | `'2010-04'`         | The month of April 2010.                         | From the 1st of April 2010 to the 30th of April 2010, inclusive.      |
+| `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year Period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
+| `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
+| `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years Period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
+| `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
+
+```yaml
+
+- name: Income tax over time
+  period: 2016-01
+  input_variables:
+    salary:
+      year:2014:3: 100000 # This person earned 100,000  between 2014 and 2016
+  output_variables:
+    income_tax:
+      2014-01: 388.8889
+      2015-01: 416.6667 # The income tax rate changes in 2015
+      2016-01: 416.6667
+      2017-01: 0 # The salary is not set for this Period and defaults to 0 
+
+```
+
+## Periods in variable definition
 
 ```py
 class salary(Variable):
@@ -20,15 +56,22 @@ class salary(Variable):
         ...
 ```
 
-The size of the period is constrained by the class attribute `definition_period`:
-  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a period that is not a month will raise an error before entering `formula`.
+Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+Therefore, all OpenFisca variables have a `definition_period` attribute.
+The size of the Period is constrained by the class attribute `definition_period`:
+  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a Period that is not a month will raise an error before entering `formula`.
   - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `formula` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
   - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `formula`. However when `formula` is executed, the parameter `period` can be anything and it should not be used.
 
+Each formula calculates a variable **for the given definition Period**. This Period is always the second argument of the formulas.
 
-## Calculating dependencies for a period different than the one they are defined for
+## Periods in formulas
 
-Calling a formula with a period that is incompatible with the attribute `definition_period` will cause an error. For instance, if we assume that a person `salary` is paid monthly:
+### Define different formulas for different 
+
+### Calculate dependencies for a Period different than the one they are defined for
+
+Calling a formula with a Period that is incompatible with the attribute `definition_period` will cause an error. For instance, if we assume that a person `salary` is paid monthly:
 
 ```py
 class taxes(Variable):
@@ -37,14 +80,14 @@ class taxes(Variable):
     label = u"Taxes for a whole year"
     definition_period = YEAR
 
-    def formula(person, period):  # period is a year because definition_period = YEAR
-        salary_past_year = person('salary', period)  # salary is computed on a year while it's a montly variable, openfisca will complain
+    def formula(person, period):  # Period is a year because definition_period = YEAR
+        salary_past_year = person('salary', period)  # salary is a montly variable. This will cause an error.
         ...
 ```
 
-However, sometimes, we do need to estimate a variable for a different period than the one it is defined for.
+However, sometimes, we do need to estimate a variable for a different Period than the one it is defined for.
 
-We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells openfisca to split the period into months, compute the variable for each month and sum up the results:
+We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells openfisca to split the Period into months, compute the variable for each month and sum up the results:
 
 ```py
 class taxes(Variable):
@@ -53,12 +96,12 @@ class taxes(Variable):
     label = u"Taxes for a whole year"
     definition_period = YEAR
 
-    def formula(person, period):  # period is a year because definition_period = YEAR
+    def formula(person, period):  # Period is a year because definition_period = YEAR
         salary_last_year = person('salary', period, options = [ADD])
         ...
 ```
 
-The option `DIVIDE` allows you to do the opposite: evaluating a quantity for a month while the variable is defined for a year. Openfisca computes the variable for the whole year that contains the specified month and then divides the result by 12.
+The option `DIVIDE` allows you to do the opposite: evaluating a quantity for a month while the variable is defined for a year. OpenFisca computes the variable for the whole year that contains the specified month and then divides the result by 12.
 
 ```py
 class salary_net_of_taxes(Variable):
@@ -67,20 +110,20 @@ class salary_net_of_taxes(Variable):
     label = u"Monthly salary, net of taxes"
     definition_period = MONTH
 
-    def formula(person, period):  # period is a month because definition_period = MONTH
+    def formula(person, period):  # Period is a month because definition_period = MONTH
         # The variable taxes is computed on a year, monthly_taxes equals the 12th of that result
         monthly_taxes = person('taxes', period, options = [DIVIDE])
 
-        # salary is a monthly variable, period is a month: no option is required
+        # salary is a monthly variable, Period is a month: no option is required
         salary = person('salary', period)
 
         return salary - monthly_taxes
 ```
 
 
-## Calculating dependencies for a specific period
+### Calculate dependencies for a specific Period
 
-It happens that the formula to calculate a variable at a given period needs the value of another variable for another period. Usually, the second period is defined relatively to the first one (previous month, last three month, current year).
+It happens that the formula to calculate a variable at a given Period needs the value of another variable for another Period. Usually, the second Period is defined relatively to the first one (previous month, last three month, current year).
 
 For instance, we want to compute an unemployment benefit that equals half of last year's salary, if the person had no income for the past 3 months.
 
@@ -99,36 +142,36 @@ class unemployment_benefit(Variable):
         return 0.5 * salary_last_year * is_unemployed
 ```
 
-You can generate any period with the following properties and methods:
+You can generate any Period with the following properties and methods:
 
 | Period                            | Meaning                                                      |
 |-----------------------------------|--------------------------------------------------------------|
-| `period.this_month`               | First month-length period that includes the start of `period`|
+| `period.this_month`               | First month-length Period that includes the start of `period`|
 | `period.last_month`               | Month preceding `period.this_month`                          |
-| `period.this_year`                | First year-length period that includes the start of `period` |
+| `period.this_year`                | First year-length Period that includes the start of `period` |
 | `period.last_year`                | Year preceding `period.this_year`                            |
 | `period.n_2`                      | 2 years before `period.this_year`                            |
-| `period.last_3_months`            | The three-month period preceding `period.this_month`         |
+| `period.last_3_months`            | The three-month Period preceding `period.this_month`         |
 | `period.offset(n, 'month')`       | `period` translated by n months (backwards if n <0)          |
 | `period.offset(n, 'year')`        | `period` translated by n years (backwards if n <0)           |
-| `period.start.period('year')`     | Year-long period starting a the same time than `period`      |
-| `period.start.period('month')`    | Month-long period starting a the same time than `period`     |
-| `period.start.period('year', n)`  | n-year-long period starting a the same time than `period`    |
-| `period.start.period('month', n)` | n-month-long period starting a the same time than `period`   |
+| `period.start.period('year')`     | Year-long Period starting a the same time than `period`      |
+| `period.start.period('month')`    | Month-long Period starting a the same time than `period`     |
+| `period.start.period('year', n)`  | n-year-long Period starting a the same time than `period`    |
+| `period.start.period('month', n)` | n-month-long Period starting a the same time than `period`   |
 
 You can find more information on the `period` object in the [reference documentation]() (_not available yet_)
 
 
-## Automatically process variable inputs defined for periods not matching the `definition_period`
+## `set_input`: Automatically process variable inputs defined for Periods not matching the `definition_period`
 
-By default, when you provide a simulation inputs, you won't a able to set a variable value for a period that doesn't match its `definition_period`.
+By default, when you provide a simulation input, you won't be able to set a variable value for a Period that doesn't match its `definition_period`.
 
-For instance, as the `definition_period` of `salary` is `MONTH`, if you provide as an input a value of `salary` for `2015`, an error will be raised.
+For instance, if the `definition_period` of `salary` is `MONTH`, and you input a value for `salary` for `2015`, an error will be raised.
 
 It is however possible to define an automatic behaviour to cast yearly inputs into monthy values. To do this, add a `set_input` class attribute to a variable.
 
-* if `set_input = set_input_divide_by_period`, the 12 months are set equal to the 12th of the input value,
-* if `set_input = set_input_dispatch_by_period`, the 12 months are set equal to input value.
+* `set_input = set_input_divide_by_period`: the 12 months are set equal to the 12th of the input value,
+* `set_input = set_input_dispatch_by_period`: the 12 months are set equal to input value.
 
 For instance, let's slightly modify the code of `salary`:
 ```py
@@ -143,4 +186,29 @@ class salary(Variable):
         ...
 ```
 
-We can now provide an input for `2015` for `salary`: no error will be raised, and the value will be automatically split between the 12 months of `2015.
+We can now provide an input for `2015` for `salary`: no error will be raised, and the value will be automatically split between the 12 months of `2015`
+
+## How to use Instants to represent cutoff dates.
+
+Sometimes, there are some results that depend on a value at a specific date.
+Instants can be used to calculate the value of a parameter or a variable at such date, for example, a scholarship that is awarded only if the student is yonger than 25 on july first of the same year.
+
+```py
+from openfisca_core.periods import Instant
+
+class eligible_for_scholarship(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        july_first = Instant(
+            (period.start.year, 7, 1)
+        ).period('month')
+
+        age_condition = person('age', july_first) <= 25
+
+        return age_condition    
+```
+
+

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -27,7 +27,7 @@ In OpenFisca inputs, periods are encoded in strings. All the valid period format
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
 
-This YAML test on `income_tax` evolution over time shows periods' impact on a variable
+This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time shows periods' impact on a variable
 
 ```yaml
 

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -19,7 +19,7 @@ An Instant is a specific day, such as a cutoff date.
 
 ## Periods in simulations
 
-In OpenFisca, Periods are encoded in strings. All the valid Period formats are referenced in this table:
+In OpenFisca inputs, Periods are encoded in strings. All the valid Period formats are referenced in this table:
 
 | Period format     | Period type     | Example             | Represents                                       | Disambiguation                                                        |
 |-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
@@ -62,15 +62,14 @@ class salary(Variable):
         ...
 ```
 
-Most of the values calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+Most of the values calculated in OpenFisca, such as `income_tax`, and `housing_allowance`, can change over time. 
 
-Therefore, all OpenFisca variables have a `definition_period` attribute.
-The size of the Period is constrained by the class attribute `definition_period`:
+Therefore, all OpenFisca variables have a `definition_period` attribute:
   - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a Period that is not a month will raise an error before entering `formula`.
   - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `formula` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
   - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `formula`. However when `formula` is executed, the parameter `period` can be anything and it should not be used.
 
-Each formula calculates a variable **for the given definition Period**. This Period is always the second argument of the formulas.
+Each formula calculates the value of a variable for a Period the size of **the given definition Period**. This Period is always the second argument of the formulas.
 
 ## Periods in formulas
 

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -1,37 +1,37 @@
 # Periods and instants
 
-A Period can be a month, a year, `n` successive months, `n` successive years or the eternity.
-The smallest unit for OpenFisca Periods is the **month**. Therefore:
+A period can be a month, a year, `n` successive months, `n` successive years or the eternity.
+The smallest unit for OpenFisca periods is the **month**. Therefore:
 
-- All Periods are presumed to start on the first day of their first month.
-- A Period cannot be smaller than a month.
-- To manipulate periods (e.g. create a new Period, create an Instant, ...), you will need to import the `periods` module like this :
+- All periods are presumed to start on the first day of their first month.
+- A period cannot be smaller than a month.
+- To manipulate periods (e.g. create a new period), you will need to import the `periods` module like this :
 ```py
 from openfisca_core import periods
 ```
 
 An Instant is a specific day, such as a cutoff date.
 
-> Internally, Periods are stored as:
+> Internally, periods are stored as:
 > - a start instant
 > - a unit (MONTH, YEAR)
 > - a quantity of units.
 
 ## Periods in simulations
 
-In OpenFisca inputs, Periods are encoded in strings. All the valid Period formats are referenced in this table:
+In OpenFisca inputs, periods are encoded in strings. All the valid period formats are referenced in this table:
 
 | Period format     | Period type     | Example             | Represents                                       | Disambiguation                                                        |
 |-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
 | `AAAA`            | Calendar year   | `'2010'`            | The year 2010.                                   | From the 1st of January 2010 to the 31st of December 2010, inclusive. |
 | `AAAA-MM`         | Month           | `'2010-04'`         | The month of April 2010.                         | From the 1st of April 2010 to the 30th of April 2010, inclusive.      |
-| `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year Period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
+| `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
-| `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years Period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
+| `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
 
-This YAML test on `income_tax` evolution over time shows Periods' impact on a variable
+This YAML test on `income_tax` evolution over time shows periods' impact on a variable
 
 ```yaml
 
@@ -45,7 +45,7 @@ This YAML test on `income_tax` evolution over time shows Periods' impact on a va
       2014-01: 388.8889
       2015-01: 416.6667 # The income tax rate changes in 2015
       2016-01: 416.6667
-      2017-01: 0 # The salary is not set for this Period and defaults to 0 
+      2017-01: 0 # The salary is not set for this period and defaults to 0 
 
 ```
 
@@ -65,17 +65,17 @@ class salary(Variable):
 Most of the values calculated in OpenFisca, such as `income_tax`, and `housing_allowance`, can change over time. 
 
 Therefore, all OpenFisca variables have a `definition_period` attribute:
-  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a Period that is not a month will raise an error before entering `formula`.
+  - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a period that is not a month will raise an error before entering `formula`.
   - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `formula` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
   - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `formula`. However when `formula` is executed, the parameter `period` can be anything and it should not be used.
 
-Each formula calculates the value of a variable for a Period the size of **the given definition Period**. This Period is always the second argument of the formulas.
+Each formula calculates the value of a variable for a period the size of **the given definition period**. This period is always the second argument of the formulas.
 
 ## Periods in formulas
 
-### Calculate dependencies for a Period different than the variable's `definition_period`
+### Calculate dependencies for a period different than the variable's `definition_period`
 
-Calling a formula with a Period that is incompatible with the attribute `definition_period` will cause an error. For instance, if we assume that a person `salary` is paid monthly:
+Calling a formula with a period that is incompatible with the attribute `definition_period` will cause an error. For instance, if we assume that a person `salary` is paid monthly:
 
 ```py
 class taxes(Variable):
@@ -89,9 +89,9 @@ class taxes(Variable):
         ...
 ```
 
-However, sometimes, we do need to estimate a variable for a different Period than the one it is defined for.
+However, sometimes, we do need to estimate a variable for a different period than the one it is defined for.
 
-We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells openfisca to split the Period into months, compute the variable for each month and sum up the results:
+We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells openfisca to split the period into months, compute the variable for each month and sum up the results:
 
 ```py
 class taxes(Variable):
@@ -118,16 +118,16 @@ class salary_net_of_taxes(Variable):
         # The variable taxes is computed on a year, monthly_taxes equals the 12th of that result
         monthly_taxes = person('taxes', period, options = [DIVIDE])
 
-        # salary is a monthly variable, Period is a month: no option is required
+        # salary is a monthly variable, period is a month: no option is required
         salary = person('salary', period)
 
         return salary - monthly_taxes
 ```
 
 
-### Calculate dependencies for a specific Period
+### Calculate dependencies for a specific period
 
-It happens that the formula to calculate a variable at a given Period needs the value of another variable for another Period. Usually, the second Period is defined relatively to the first one (previous month, last three month, current year).
+It happens that the formula to calculate a variable at a given period needs the value of another variable for another period. Usually, the second period is defined relatively to the first one (previous month, last three month, current year).
 
 For instance, we want to compute an unemployment benefit that equals half of last year's salary, if the person had no income for the past 3 months.
 
@@ -146,29 +146,29 @@ class unemployment_benefit(Variable):
         return 0.5 * salary_last_year * is_unemployed
 ```
 
-You can generate any Period with the following properties and methods:
+You can generate any period with the following properties and methods:
 
 | Period                            | Meaning                                                      |
 |-----------------------------------|--------------------------------------------------------------|
-| `period.this_month`               | First month-length Period that includes the start of `period`|
+| `period.this_month`               | First month-length period that includes the start of `period`|
 | `period.last_month`               | Month preceding `period.this_month`                          |
-| `period.this_year`                | First year-length Period that includes the start of `period` |
+| `period.this_year`                | First year-length period that includes the start of `period` |
 | `period.last_year`                | Year preceding `period.this_year`                            |
 | `period.n_2`                      | 2 years before `period.this_year`                            |
-| `period.last_3_months`            | The three-month Period preceding `period.this_month`         |
+| `period.last_3_months`            | The three-month period preceding `period.this_month`         |
 | `period.offset(n, 'month')`       | `period` translated by n months (backwards if n <0)          |
 | `period.offset(n, 'year')`        | `period` translated by n years (backwards if n <0)           |
-| `period.start.period('year')`     | Year-long Period starting a the same time than `period`      |
-| `period.start.period('month')`    | Month-long Period starting a the same time than `period`     |
-| `period.start.period('year', n)`  | n-year-long Period starting a the same time than `period`    |
-| `period.start.period('month', n)` | n-month-long Period starting a the same time than `period`   |
+| `period.start.period('year')`     | Year-long period starting a the same time than `period`      |
+| `period.start.period('month')`    | Month-long period starting a the same time than `period`     |
+| `period.start.period('year', n)`  | n-year-long period starting a the same time than `period`    |
+| `period.start.period('month', n)` | n-month-long period starting a the same time than `period`   |
 
 You can find more information on the `Period` object in the [reference documentation]() (_not available yet_)
 
 
-## `set_input`: Automatically process variable inputs defined for Periods not matching the `definition_period`
+## `set_input`: Automatically process variable inputs defined for periods not matching the `definition_period`
 
-By default, when you provide a simulation input, you won't be able to set a variable value for a Period that doesn't match its `definition_period`.
+By default, when you provide a simulation input, you won't be able to set a variable value for a period that doesn't match its `definition_period`.
 
 For instance, if the `definition_period` of `salary` is `MONTH`, and you input a value for `salary` for `2015`, an error will be raised.
 

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -5,7 +5,10 @@ The smallest unit for OpenFisca Periods is the **month**. Therefore:
 
 - All Periods are presumed to start on the first day of their first month.
 - A Period cannot be smaller than a month.
-
+- To manipulate periods (e.g. create a new Period, create an Instant, ...), you will need to import the `periods` module like this :
+```py
+from openfisca_core import periods
+```
 
 An Instant is a specific day, such as a cutoff date.
 

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -26,6 +26,7 @@ In OpenFisca, Periods are encoded in strings. All the valid Period formats are r
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
 | `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years Period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
+| `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
 
 ```yaml
 
@@ -66,8 +67,6 @@ The size of the Period is constrained by the class attribute `definition_period`
 Each formula calculates a variable **for the given definition Period**. This Period is always the second argument of the formulas.
 
 ## Periods in formulas
-
-### Define different formulas for different 
 
 ### Calculate dependencies for a Period different than the one they are defined for
 
@@ -190,8 +189,8 @@ We can now provide an input for `2015` for `salary`: no error will be raised, an
 
 ## How to use Instants to represent cutoff dates.
 
-Sometimes, there are some results that depend on a value at a specific date.
-Instants can be used to calculate the value of a parameter or a variable at such date, for example, a scholarship that is awarded only if the student is yonger than 25 on july first of the same year.
+Sometimes, some results depend on a value calculted at a specific date.
+Instants can be used to calculate the value of a parameter or a variable at such date, for example, a scholarship that is awarded only if the student is yonger than 25 on july first of the same year:
 
 ```py
 from openfisca_core.periods import Instant

--- a/coding-the-legislation/35_periods.md
+++ b/coding-the-legislation/35_periods.md
@@ -9,7 +9,7 @@ The smallest unit for OpenFisca Periods is the **month**. Therefore:
 
 An Instant is a specific day, such as a cutoff date.
 
-> Internally, time, Periods are stored as:
+> Internally, Periods are stored as:
 > - a start instant
 > - a unit (MONTH, YEAR)
 > - a quantity of units.
@@ -28,13 +28,15 @@ In OpenFisca, Periods are encoded in strings. All the valid Period formats are r
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
 
+This YAML test on `income_tax` evolution over time shows Periods' impact on a variable
+
 ```yaml
 
 - name: Income tax over time
   period: 2016-01
   input_variables:
     salary:
-      year:2014:3: 100000 # This person earned 100,000  between 2014 and 2016
+      year:2014:3: 100000 # This person earned 100,000 between 2014 and 2016
   output_variables:
     income_tax:
       2014-01: 388.8889
@@ -57,7 +59,8 @@ class salary(Variable):
         ...
 ```
 
-Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+Most of the values calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+
 Therefore, all OpenFisca variables have a `definition_period` attribute.
 The size of the Period is constrained by the class attribute `definition_period`:
   - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a Period that is not a month will raise an error before entering `formula`.
@@ -68,7 +71,7 @@ Each formula calculates a variable **for the given definition Period**. This Per
 
 ## Periods in formulas
 
-### Calculate dependencies for a Period different than the one they are defined for
+### Calculate dependencies for a Period different than the variable's `definition_period`
 
 Calling a formula with a Period that is incompatible with the attribute `definition_period` will cause an error. For instance, if we assume that a person `salary` is paid monthly:
 
@@ -79,7 +82,7 @@ class taxes(Variable):
     label = u"Taxes for a whole year"
     definition_period = YEAR
 
-    def formula(person, period):  # Period is a year because definition_period = YEAR
+    def formula(person, period):  # period is a year because definition_period = YEAR
         salary_past_year = person('salary', period)  # salary is a montly variable. This will cause an error.
         ...
 ```
@@ -92,10 +95,10 @@ We may for example want to get the sum of the salaries perceived on the past yea
 class taxes(Variable):
     value_type = float
     entity = Person
-    label = u"Taxes for a whole year"
+    label = "Taxes for a whole year"
     definition_period = YEAR
 
-    def formula(person, period):  # Period is a year because definition_period = YEAR
+    def formula(person, period):  # period is a year because definition_period = YEAR
         salary_last_year = person('salary', period, options = [ADD])
         ...
 ```
@@ -109,7 +112,7 @@ class salary_net_of_taxes(Variable):
     label = u"Monthly salary, net of taxes"
     definition_period = MONTH
 
-    def formula(person, period):  # Period is a month because definition_period = MONTH
+    def formula(person, period):  # period is a month because definition_period = MONTH
         # The variable taxes is computed on a year, monthly_taxes equals the 12th of that result
         monthly_taxes = person('taxes', period, options = [DIVIDE])
 
@@ -158,7 +161,7 @@ You can generate any Period with the following properties and methods:
 | `period.start.period('year', n)`  | n-year-long Period starting a the same time than `period`    |
 | `period.start.period('month', n)` | n-month-long Period starting a the same time than `period`   |
 
-You can find more information on the `period` object in the [reference documentation]() (_not available yet_)
+You can find more information on the `Period` object in the [reference documentation]() (_not available yet_)
 
 
 ## `set_input`: Automatically process variable inputs defined for Periods not matching the `definition_period`
@@ -185,7 +188,7 @@ class salary(Variable):
         ...
 ```
 
-We can now provide an input for `2015` for `salary`: no error will be raised, and the value will be automatically split between the 12 months of `2015`
+We can now provide an input for `2015` for `salary`: no error will be raised, and the value will be automatically split between the 12 months of `2015`.
 
 ## How to use Instants to represent cutoff dates.
 

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -1,10 +1,10 @@
 # Periods, Instants
 
-Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+Most of the values calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
 
 ## Time concepts in OpenFisca
 
-In simulations, tests and parameters, variables and formulas, OpenFisca manipulates time via *periods* and *instants*.
+In [simulations](http://openfisca.org/doc/simulation.html), tests and parameters, variables and formulas, OpenFisca manipulates time via *periods* and *instants*.
 
 - *Instant*: the atomic unit is a day, so instants are day dates.
 
@@ -25,14 +25,14 @@ The largest unit for OpenFisca periods is the **eternity**. The value of the var
 [Implementation options and helper functions](coding-the-legislation/35_periods.md) exist to transform periods or turn them into an instant.
 
 
-## Legislation Evolution 
+## Legislation evolution 
 
-Both the formulas that calculates a variable, and the values of a parameters can change over time.
+Both the formulas that calculate a variable and the values of a parameter can change over time.
 OpenFisca has mechanisms in place to define changes in the legislation that uses Instants.
 
 ### Define a start date and an end date for a formula
 
-The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#formula-evolution)
+The formula that calculates a variable might only be valid from a start date and before an end date. 
 
 ```py
 class salary(Variable):
@@ -40,15 +40,18 @@ class salary(Variable):
     entity = Person
     label = u"Salary for a month"
     definition_period = MONTH
-    end = '2016-11-30'
+    end = '2018-11-30'
     def formula_2017_01_01(person, period, parameters):
         ...
     def formula(person, period):
         ...
 ```
+
+To learn more, check out our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#formula-evolution).
+
 ### How to update a parameter
 
-The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#how-to-update-a-parameter)
+The value for a parameter also can evolve over time. 
 
 ```yaml
 taxes:
@@ -64,6 +67,5 @@ taxes:
           reference: https://www.legislation-source.com/2015
 ```
 
-
-
+To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#how-to-update-a-parameter).
 

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -2,8 +2,6 @@
 
 Most of the values calculated in OpenFisca, such as an _income tax_, or a _housing allowance_, can change over time.  
 
-## Time concepts in OpenFisca
-
 In [simulations](simulation.md), parameters and variables, OpenFisca handles time via *periods* and *instants*.
 
 - *Instant*: the atomic unit is a day, so instants are day dates.
@@ -23,48 +21,3 @@ The smallest unit for OpenFisca periods is the **month**. Therefore:
 The largest unit for OpenFisca periods is the **eternity**, i.e. value of the variable is constant over time, e.g. a date of birth.
 
 [Read more about the periods implementation in OpenFisca](coding-the-legislation/35_periods.md)
-
-## Legislation evolution 
-
-Both the formulas that calculate a variable and the values of a parameter can change over time.
-OpenFisca has mechanisms in place to define changes in the legislation that uses Instants.
-
-### Define a start date and an end date for a formula
-
-The formula that calculates a variable might only be valid from a start date and before an end date. 
-
-```py
-class salary(Variable):
-    value_type = float
-    entity = Person
-    label = u"Salary for a month"
-    definition_period = MONTH
-    end = '2018-11-30'
-    def formula_2017_01_01(person, period, parameters):
-        ...
-    def formula(person, period):
-        ...
-```
-
-To learn more, check out our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#formula-evolution).
-
-### How to update a parameter
-
-The value for a parameter also can evolve over time. 
-
-```yaml
-taxes:
-  salary:
-    rate:
-      description: Rate for the flat tax on salaries
-      values:
-        2016-01-01:
-          value: 0.25
-          reference: https://www.legislation-source.com/2016
-        2015-01-01:
-          value: 0.20
-          reference: https://www.legislation-source.com/2015
-```
-
-To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#how-to-update-a-parameter).
-

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -1,6 +1,10 @@
 # Periods, Instants
 
-Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. OpenFisca manipulates time via *periods* and *instants*.
+Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+
+## Time concepts in OpenFisca
+
+In simulations, tests and parameters, variables and formulas, OpenFisca manipulates time via *periods* and *instants*.
 
 - *Instant*: the atomic unit is a day, so instants are day dates.
 
@@ -10,11 +14,56 @@ _Example: the 15th June 2015._
 
 _Example: a month ("July 2015"), a year ("2015"), several months ("July and August 2015") or the eternity._
 
+
 The smallest unit for OpenFisca periods is the **month**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a month.
 
+The largest unit for OpenFisca periods is the **eternity**. The value of the variable is constant over time, e.g. a date of birth.
 
 [Implementation options and helper functions](coding-the-legislation/35_periods.md) exist to transform periods or turn them into an instant.
+
+
+## Legislation Evolution 
+
+Both the formulas that calculates a variable, and the values of a parameters can change over time.
+OpenFisca has mechanisms in place to define changes in the legislation that uses Instants.
+
+### Define a start date and an end date for a formula
+
+The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](40_legislation_evolutions.md/#formula-evolution)
+
+```py
+class salary(Variable):
+    value_type = float
+    entity = Person
+    label = u"Salary for a month"
+    definition_period = MONTH
+    end = '2016-11-30'
+    def formula_2017_01_01(person, period, parameters):
+        ...
+    def formula(person, period):
+        ...
+```
+### How to update a parameter
+
+The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](40_legislation_evolutions.md/#how-to-update-a-parameter)
+
+```yaml
+taxes:
+  salary:
+    rate:
+      description: Rate for the flat tax on salaries
+      values:
+        2016-01-01:
+          value: 0.25
+          reference: https://www.legislation-source.com/2016
+        2015-01-01:
+          value: 0.20
+          reference: https://www.legislation-source.com/2015
+```
+
+
+
 

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -1,10 +1,10 @@
 # Periods, Instants
 
-Most of the values calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. 
+Most of the values calculated in OpenFisca, such as an _income tax_, or a _housing allowance_, can change over time.  
 
 ## Time concepts in OpenFisca
 
-In [simulations](http://openfisca.org/doc/simulation.html), tests and parameters, variables and formulas, OpenFisca manipulates time via *periods* and *instants*.
+In [simulations](simulation.md), parameters and variables, OpenFisca handles time via *periods* and *instants*.
 
 - *Instant*: the atomic unit is a day, so instants are day dates.
 
@@ -20,10 +20,9 @@ The smallest unit for OpenFisca periods is the **month**. Therefore:
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a month.
 
-The largest unit for OpenFisca periods is the **eternity**. The value of the variable is constant over time, e.g. a date of birth.
+The largest unit for OpenFisca periods is the **eternity**, i.e. value of the variable is constant over time, e.g. a date of birth.
 
-[Implementation options and helper functions](coding-the-legislation/35_periods.md) exist to transform periods or turn them into an instant.
-
+[Read more about the periods implementation in OpenFisca](coding-the-legislation/35_periods.md)
 
 ## Legislation evolution 
 

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -18,6 +18,6 @@ The smallest unit for OpenFisca periods is the **month**. Therefore:
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a month.
 
-The largest unit for OpenFisca periods is the **eternity**, i.e. value of the variable is constant over time, e.g. a date of birth.
+The largest unit for OpenFisca periods is the **eternity**, which is used for variables that are constant over time, e.g. a date of birth.
 
 [Read more about the periods implementation in OpenFisca](coding-the-legislation/35_periods.md)

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -1,8 +1,6 @@
 # Periods, Instants
 
-#### Definition
-
-OpenFisca manipulates time via *periods* and *instants*.
+Most of the quantities calculated in OpenFisca, such as `income tax`, and `housing allowance`, can change over time. OpenFisca manipulates time via *periods* and *instants*.
 
 - *Instant*: the atomic unit is a day, so instants are day dates.
 
@@ -12,25 +10,11 @@ _Example: the 15th June 2015._
 
 _Example: a month ("July 2015"), a year ("2015"), several months ("July and August 2015") or the eternity._
 
-#### API
-
-In OpenFisca, periods are encoded in strings. All the valid period formats are referenced in this table:
-
-| Period format     | Period type     | Example             | Represents                                       | Disambiguation                                                        |
-|-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
-| `AAAA`            | Calendar year   | `'2010'`            | The year 2010.                                   | From the 1st of January 2010 to the 31st of December 2010, inclusive. |
-| `AAAA-MM`         | Month           | `'2010-04'`         | The month of April 2010.                         | From the 1st of April 2010 to the 30th of April 2010, inclusive.      |
-| `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
-| `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
-| `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
-| `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
-
 The smallest unit for OpenFisca periods is the **month**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a month.
 
-> Internally, time is stored as a start instant, a unit (MONTH, YEAR) and a quantity of units.
 
-[Helper functions](coding-the-legislation/35_periods.md) exist to transform periods or turn them into an instant.
+[Implementation options and helper functions](coding-the-legislation/35_periods.md) exist to transform periods or turn them into an instant.
 

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -32,7 +32,7 @@ OpenFisca has mechanisms in place to define changes in the legislation that uses
 
 ### Define a start date and an end date for a formula
 
-The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md/#formula-evolution)
+The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#formula-evolution)
 
 ```py
 class salary(Variable):
@@ -48,7 +48,7 @@ class salary(Variable):
 ```
 ### How to update a parameter
 
-The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md/#how-to-update-a-parameter)
+The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md#how-to-update-a-parameter)
 
 ```yaml
 taxes:

--- a/periodsinstants.md
+++ b/periodsinstants.md
@@ -32,7 +32,7 @@ OpenFisca has mechanisms in place to define changes in the legislation that uses
 
 ### Define a start date and an end date for a formula
 
-The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](40_legislation_evolutions.md/#formula-evolution)
+The formula that calculate can change. To learn more, checkout the our [legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md/#formula-evolution)
 
 ```py
 class salary(Variable):
@@ -48,7 +48,7 @@ class salary(Variable):
 ```
 ### How to update a parameter
 
-The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](40_legislation_evolutions.md/#how-to-update-a-parameter)
+The value for a parameter also can evolve. To learn more, checkout the our[legislation evolutions page](coding-the-legislation/40_legislation_evolutions.md/#how-to-update-a-parameter)
 
 ```yaml
 taxes:


### PR DESCRIPTION
Fixes #141 
This PR : 
- Takes the technical information about periods out of `Key Concepts` and into the dedicated `From Law to Code`page
- Adds information about the `ETERNITY` period on both pages
- Adds information about legislation evolution on the `Key Concepts` page .
- Adds information on Instants on the `From Law to Code`page