### PR TITLE
Add /entities endpoint in official documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /_book
 /node_modules
+npm-debug.log

--- a/openfisca-web-api/endpoints.md
+++ b/openfisca-web-api/endpoints.md
@@ -4,5 +4,6 @@ Each OpenFisca Country Package web API comes with a set of endpoints including a
 You can check out the `OpenFisca-France` [swagger documentation](https://fr.openfisca.org/legislation/swagger) to see how their endpoints work.
 
 The Openfisca Web API can be used to:
- - access information about the parameters (e.g. `/parameters`) and variables (e.g. `/variables`) of the Country Package.
+ - access information about the parameters (e.g. `/parameters`) and variables (e.g. `/variables`) of the Country Package,
+ - access information about how persons are defined in the Country Package (e.g. `/entities`),
  - run simulations (e.g. `/calculate`) on a specific situation. To describe a situation, learn more about the Web API [inputs and outputs](input-output-data.md).

--- a/openfisca-web-api/endpoints.md
+++ b/openfisca-web-api/endpoints.md
@@ -4,6 +4,5 @@ Each OpenFisca Country Package web API comes with a set of endpoints including a
 You can check out the `OpenFisca-France` [swagger documentation](https://fr.openfisca.org/legislation/swagger) to see how their endpoints work.
 
 The Openfisca Web API can be used to:
- - access information about the parameters (e.g. `/parameters`) and variables (e.g. `/variables`) of the Country Package,
- - access information about how persons are defined in the Country Package (e.g. `/entities`),
+ - access information about the parameters (e.g. `/parameters`), the variables (e.g. `/variables`), and entities (e.g. `/entities`) of the Country Package,
  - run simulations (e.g. `/calculate`) on a specific situation. To describe a situation, learn more about the Web API [inputs and outputs](input-output-data.md).

--- a/openfisca-web-api/input-output-data.md
+++ b/openfisca-web-api/input-output-data.md
@@ -3,7 +3,7 @@
 > All the examples provided here are from the [country package template](https://github.com/openfisca/country-template).
 
 In order to run a computation on the Web API, you will need to send information to the API concerning:
-- The situation, meaning describe the entities (e.g. individuals, households) that you want to base your calculations on.
+- The situation, meaning describe the [entities](http://openfisca.org/doc/person,_entities,_role.html) (e.g. individuals, households) that you want to base your calculations on.
 - The variable you need to compute.
 
 ## Describing the situation


### PR DESCRIPTION
Fixes #161 

Adds `/entities` endpoint to web API endpoints list.
And help understanding entities in web API inputs/outputs page by adding a link to entities page.