### PR TITLE
Allow redeploy and fix minor style issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           name: Check for internal dead links
           command: wget --spider --recursive --page-requisites http://localhost:8000
 
-      - save_cache:
-          key: build-cache-{{ .Revision }}
+      - persist_to_workspace:
+          root: .
           paths:
             - build
 
@@ -49,8 +49,8 @@ jobs:
       - image: python:3.7
     steps:
       - checkout
-      - restore_cache:
-          key: build-cache-{{ .Revision }}
+      - attach_workspace:
+          at: .
       - run:
           name: Publish openfisca.org/doc
           command: ./publish.sh

--- a/source/_static/style.css
+++ b/source/_static/style.css
@@ -28,6 +28,10 @@ pre {
   background: #f7f7f7;
 }
 
+code {
+  font-size: inherit;
+}
+
 /* Trick to avoid local links to appear in the side bar. We want only pages theres, but mixing markdown and rst creates some confusion. */
 .toctree-l2 a[href*="index.html#"], .toctree-l2 a[href^="#"]:not([href="#"]) {
   display: none;

--- a/source/index.md
+++ b/source/index.md
@@ -1,6 +1,6 @@
 [![OpenFisca logo](https://openfisca.org/img/logo-openfisca.svg)](https://openfisca.org)
 
-> Download a [PDF offline version](https://media.readthedocs.org/pdf/openfisca-doc/latest/openfisca-doc.pdf) of this documentation.
+> Download a [PDF offline version](https://media.readthedocs.org/pdf/openfisca/latest/openfisca.pdf) of this documentation.
 
 # Introduction
 


### PR DESCRIPTION
We should not use the cache to pass files from one job to another as:
- It's not [what cache is for](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) according to CircleCI
- It prevents redeploying the doc without modifying this repo: right now the deploy job uses a version of the build based on the SHA, so we need to commit here to really redeploy. However, as the doc depends on the content of another repo (core), we need to be able to redeploy even when there is no local change.


Also fix a minor style issue:

Before:
![image](https://user-images.githubusercontent.com/11834997/48817113-d7c4e700-ed12-11e8-85f2-ed3db75d81f3.png)

After:
![image](https://user-images.githubusercontent.com/11834997/48817117-df848b80-ed12-11e8-8d61-d5e78aa660cd.png)
