### PR TITLE
Bypass Jekyll namespaces

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -52,7 +52,7 @@ html_theme_options = {
     "homepage": "index",  # Different than the master doc
 }
 
-html_static_path = ['_static']
+html_static_path = ['static']
 
 github_doc_root = 'https://github.com/openfisca/openfisca-doc/tree/master/'
 


### PR DESCRIPTION
Fix broken style on `openfisca.org/doc` by disabling GitHub Pages Jekyll processing on html static dependencies
* Renames `_static` folder to `static` in configuration file.

