### PR TITLE
Restructure periods sections

### DIFF
--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -12,13 +12,13 @@ The main valid period formats are referenced in this table:
 |-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
 | `AAAA`            | Calendar year   | `'2010'`            | The year 2010.                                   | From the 1st of January 2010 to the 31st of December 2010, inclusive. |
 | `AAAA-MM`         | Month           | `'2010-04'`         | The month of April 2010.                         | From the 1st of April 2010 to the 30th of April 2010, inclusive.      |
-| `AAAA-MM-DD`      | Day             | `'2010-04-06'`      | The day of the 6th of April 2010.                | The whole day of the 6th of April 2010.      |
+| `AAAA-MM-DD`      | Day             | `'2010-04-06'`      | The day of April 6th 2010.                | The whole day of the 6th of April 2010.      |
 | `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
 | `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
 | `month:AAAA-MM-DD:N` | N months        | `'month:2010-04-15:3'` | The three months from mid April to mid July 2010.    | From the April 15th 2010 to the 14th of July 2010, inclusive. |
-| `day:AAAA-MM-DD:N` | N days        | `'day:2010-04-01:30'` | The thirty days of April 2010. | From the 1st of April 2010 to the 30th of April 2010, inclusive.       |
+| `day:AAAA-MM-DD:N` | N days        | `'day:2010-04-01:15'` | The first 15 days of April 2010. | From the 1st of April 2010 to the 15th of April 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year. |
 
 > The starting instant can be shortened to a month or a year. Then, OpenFisca will implicitly use the first day of the first month.
@@ -38,7 +38,7 @@ This is equivalent to this more precise variant:
 simulation.calculate('housing_allowance', 'month:2019-05-01:1')
 ```
 
-## Manipulating Period objects in Python
+## Handling Period objects in Python
 
 To create a `Period`, you can use a simplified syntax. Here is an example for a period of one year covering `2015`:
 
@@ -76,7 +76,6 @@ Therefore, all OpenFisca variables have a `definition_period` attribute:
 
 ```py
 ...
-from openfisca_core.periods import MONTH  # openfisca_core is the architecture of OpenFisca
 
 class salary(Variable):
     value_type = float
@@ -217,7 +216,7 @@ This example sets 3 years salaries for two persons and calculates how much they 
 # Each person earned 60,000 between 2014 and 2016
 simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
 
-one_month_salaries = simulation.calculate('salary', 'month:2014-01:1')
+one_month_salaries = simulation.calculate('salary', '2014-01')
 print(one_month_salaries)  # prints [1666.6666 1666.6666]
 ```
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -31,7 +31,6 @@ In OpenFisca inputs, periods are encoded in strings. All the valid period format
 This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time shows periods' impact on a variable:
 
 ```yaml
-
 - name: Income tax over time
   period: 2016-01
   input:
@@ -43,8 +42,25 @@ This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time show
       2015-01: 416.6667 # The income tax rate changes in 2015
       2016-01: 416.6667
       2017-01: 0 # The salary is not set for this period and defaults to 0
-
 ```
+
+This syntax could also be used in Python.  
+This example sets salaries for two persons:
+
+```py
+# Each person earned 60,000 between 2014 and 2016
+simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
+```
+
+The same syntax could also be used to calculate a variable when the variable has a [set_input](coding-the-legislation/35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period) attribute:
+
+```py
+simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
+
+two_years_salary = simulation.calculate_add('salary', 'year:2014:2')
+print(two_years_salary)  # prints [40000. 40000.]
+```
+
 
 ## Periods in variable definition
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -72,13 +72,13 @@ This example sets salaries for two persons:
 simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
 ```
 
-The same syntax could also be used to calculate a variable when the variable has a [set_input](coding-the-legislation/35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period) attribute:
+The same syntax could also be used to calculate a variable when the variable has a [set_input](35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period) attribute:
 
 ```py
 simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
 
-two_years_salaries = simulation.calculate_add('salary', 'year:2014:2')
-print(two_years_salaries)  # prints [40000. 40000.]
+one_month_salaries = simulation.calculate('salary', 'month:2014-01:1')
+print(one_month_salaries)  # prints [1666.6666 1666.6666]
 ```
 
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -1,16 +1,12 @@
-# Periods and Instants
+# Specifying periods
 
-A `Period` can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.  
-An `Instant` is a specific day, such as a cutoff date.
+When you run an OpenFisca simulation to compute a variable, you need to define the period of interest for this variable.
 
-You will mainly use `Period` objects.
+OpenFisca gives you a convenient string syntax to define periods.
 
-The smallest unit for OpenFisca periods is the **day**.  
-Larger periods, like `month` or `year`, are presumed to start on the first day of their first month.
+The general structure is `unit:instant:quantity` (see the [definition of a period](../key-concepts/periodsinstants.md)). Some of the structure can be omitted. 
 
-## Periods in simulations
-
-In OpenFisca inputs, periods are encoded in strings. All the valid period formats are referenced in this table:
+All the valid period formats are referenced in this table:
 
 | Period format     | Period type     | Example             | Represents                                       | Disambiguation                                                        |
 |-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
@@ -21,8 +17,28 @@ In OpenFisca inputs, periods are encoded in strings. All the valid period format
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
 | `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
+| `month:AAAA-MM-DD:N` | N months        | `'month:2010-04-15:3'` | The three months from mid April to mid July 2010.    | From the April 15th 2010 to the 14th of July 2010, inclusive. |
 | `day:AAAA-MM-DD:N` | N days        | `'day:2010-04-01:30'` | The thirty days of April 2010. | From the 1st of April 2010 to the 30th of April 2010, inclusive.       |
-| `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
+| `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year. |
+
+> The starting instant can be shortened to a month or a year. Then, OpenFisca will implicitly use the first day of the first month.
+
+
+## Using periods in a simulation
+
+As an example, here is how to calculate a `housing_allowance` on a given month:
+
+```py
+simulation.calculate('housing_allowance', '2019-05')
+```
+
+This is equivalent to this more precise variant:
+
+```py
+simulation.calculate('housing_allowance', 'month:2019-05-01:1')
+```
+
+## Using periods in tests
 
 This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time shows periods' impact on a variable:
 
@@ -67,10 +83,11 @@ from openfisca_core import periods
 period_2015 = periods.period('2015')
 ```
 
-> Internally, periods are stored as:
-> - a start `Instant`
-> - a unit (`DAY`, `MONTH`, `YEAR`)
-> - a quantity of units.
+Internally, periods are stored as:
+- a unit (`DAY`, `MONTH`, `YEAR`)
+- a starting `Instant`
+- a quantity of units.
+
 
 The previous example could also be defined as:
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -1,17 +1,37 @@
-# Periods and instants
+# Periods and Instants
 
-A period can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.
+A `Period` can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.
+
 The smallest unit for OpenFisca periods is the **day**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
 - A period cannot be smaller than a day.
 
-An Instant is a specific day, such as a cutoff date.
+An `Instant` is a specific day, such as a cutoff date.
 
-> Internally, periods are stored as:
-> - a start instant
-> - a unit (DAY, MONTH, YEAR)
-> - a quantity of units.
+
+## Periods creation
+
+To create a `Period`, you can use a simplified syntax. Here is an example for a period of one year covering `2015`:
+
+```py
+from openfisca_core import periods
+
+period_2015 = periods.period('2015')
+```
+
+Internally, periods are stored as:
+- a start `Instant`
+- a unit (`DAY`, `MONTH`, `YEAR`)
+- a quantity of units.
+
+Thus, the previous example could also be defined as:
+
+```py
+from openfisca_core import periods
+
+period_2015 = periods.Period(('month', periods.Instant((2015, 1, 1)), 12))
+```
 
 ## Periods in simulations
 
@@ -57,14 +77,17 @@ The same syntax could also be used to calculate a variable when the variable has
 ```py
 simulation.set_input('salary', 'year:2014:3', [60000.0, 60000.0])
 
-two_years_salary = simulation.calculate_add('salary', 'year:2014:2')
-print(two_years_salary)  # prints [40000. 40000.]
+two_years_salaries = simulation.calculate_add('salary', 'year:2014:2')
+print(two_years_salaries)  # prints [40000. 40000.]
 ```
 
 
 ## Periods in variable definition
 
 ```py
+...
+from openfisca_core.periods import MONTH  # openfisca_core is the architecture of OpenFisca
+
 class salary(Variable):
     value_type = float
     entity = Person

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -9,30 +9,6 @@ The smallest unit for OpenFisca periods is the **day**. Therefore:
 
 An `Instant` is a specific day, such as a cutoff date.
 
-
-## Periods creation
-
-To create a `Period`, you can use a simplified syntax. Here is an example for a period of one year covering `2015`:
-
-```py
-from openfisca_core import periods
-
-period_2015 = periods.period('2015')
-```
-
-Internally, periods are stored as:
-- a start `Instant`
-- a unit (`DAY`, `MONTH`, `YEAR`)
-- a quantity of units.
-
-Thus, the previous example could also be defined as:
-
-```py
-from openfisca_core import periods
-
-period_2015 = periods.Period(('month', periods.Instant((2015, 1, 1)), 12))
-```
-
 ## Periods in simulations
 
 In OpenFisca inputs, periods are encoded in strings. All the valid period formats are referenced in this table:
@@ -81,6 +57,28 @@ one_month_salaries = simulation.calculate('salary', 'month:2014-01:1')
 print(one_month_salaries)  # prints [1666.6666 1666.6666]
 ```
 
+## Manipulating Period objects in Python
+
+To create a `Period`, you can use a simplified syntax. Here is an example for a period of one year covering `2015`:
+
+```py
+from openfisca_core import periods
+
+period_2015 = periods.period('2015')
+```
+
+> Internally, periods are stored as:
+> - a start `Instant`
+> - a unit (`DAY`, `MONTH`, `YEAR`)
+> - a quantity of units.
+
+Thus, the previous example could also be defined as:
+
+```py
+from openfisca_core import periods
+
+period_2015 = periods.Period(('month', periods.Instant((2015, 1, 1)), 12))
+```
 
 ## Periods in variable definition
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -21,8 +21,12 @@ The main valid period formats are referenced in this table:
 | `day:AAAA-MM-DD:N` | N days        | `'day:2010-04-01:15'` | The first 15 days of April 2010. | From the 1st of April 2010 to the 15th of April 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year. |
 
-> The starting instant can be shortened to a month or a year. Then, OpenFisca will implicitly use the first day of the first month.
+The starting instant can be shortened to a month or a year. Then, OpenFisca will implicitly use the first day of the first month.
 
+> Internally, periods come from `openfisca_core.periods` and are stored as:
+> - a unit (`DAY`, `MONTH`, `YEAR`)
+> - a starting `Instant`
+> - a quantity of units.
 
 ## Using periods in a simulation
 
@@ -36,31 +40,6 @@ This is equivalent to this more precise variant:
 
 ```py
 simulation.calculate('housing_allowance', 'month:2019-05-01:1')
-```
-
-## Handling Period objects in Python
-
-To create a `Period`, you can use a simplified syntax. Here is an example for a period of one year covering `2015`:
-
-```py
-from openfisca_core import periods
-
-period_2015 = periods.period('2015')
-```
-
-Internally, periods are stored as:
-- a unit (`DAY`, `MONTH`, `YEAR`)
-- a starting `Instant`
-- a quantity of units.
-
-
-The previous example could also be defined as:
-
-```py
-from openfisca_core import periods
-from openfisca_core.model_api import MONTH
-
-period_2015 = periods.Period((MONTH, periods.Instant((2015, 1, 1)), 12))
 ```
 
 ## Periods in variable definitions

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -1,13 +1,12 @@
 # Periods and Instants
 
-A `Period` can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.
-
-The smallest unit for OpenFisca periods is the **day**. Therefore:
-
-- All periods are presumed to start on the first day of their first month.
-- A period cannot be smaller than a day.
-
+A `Period` can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.  
 An `Instant` is a specific day, such as a cutoff date.
+
+You will mainly use `Period` objects.
+
+The smallest unit for OpenFisca periods is the **day**.  
+Larger periods, like `month` or `year`, are presumed to start on the first day of their first month.
 
 ## Periods in simulations
 
@@ -17,6 +16,7 @@ In OpenFisca inputs, periods are encoded in strings. All the valid period format
 |-------------------|-----------------|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
 | `AAAA`            | Calendar year   | `'2010'`            | The year 2010.                                   | From the 1st of January 2010 to the 31st of December 2010, inclusive. |
 | `AAAA-MM`         | Month           | `'2010-04'`         | The month of April 2010.                         | From the 1st of April 2010 to the 30th of April 2010, inclusive.      |
+| `AAAA-MM-DD`      | Day             | `'2010-04-06'`      | The day of the 6th of April 2010.                | The whole day of the 6th of April 2010.      |
 | `year:AAAA-MM`    | Rolling year    | `'year:2010-04'`    | The 1 year period starting in April 2010. | From the 1st of April 2010 to the 31st of March 2011, inclusive       |
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
 | `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
@@ -72,7 +72,7 @@ period_2015 = periods.period('2015')
 > - a unit (`DAY`, `MONTH`, `YEAR`)
 > - a quantity of units.
 
-Thus, the previous example could also be defined as:
+The previous example could also be defined as:
 
 ```py
 from openfisca_core import periods

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -1,4 +1,4 @@
-# Specifying periods
+# Periods
 
 When you run an OpenFisca simulation to compute a variable, you need to define the period of interest for this variable.
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -1,16 +1,16 @@
 # Periods and instants
 
-A period can be a month, a year, `n` successive months, `n` successive years or the eternity.
-The smallest unit for OpenFisca periods is the **month**. Therefore:
+A period can be a day, a month, a year, `n` successive days, `n` successive months, `n` successive years or the eternity.
+The smallest unit for OpenFisca periods is the **day**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
-- A period cannot be smaller than a month.
+- A period cannot be smaller than a day.
 
 An Instant is a specific day, such as a cutoff date.
 
 > Internally, periods are stored as:
 > - a start instant
-> - a unit (MONTH, YEAR)
+> - a unit (DAY, MONTH, YEAR)
 > - a quantity of units.
 
 ## Periods in simulations
@@ -25,9 +25,10 @@ In OpenFisca inputs, periods are encoded in strings. All the valid period format
 | `year:AAAA:N`     | N years         | `'year:2010:3'`     | The years 2010, 2011 and 2012.                   | From the 1st of January 2010 to the 31st of December 2012, inclusive. |
 | `year:AAAA-MM:N`  | N rolling years | `'year:2010-04:3'`  | The three years period starting in April 2010.   | From the 1st of April 2010 to the 31st of March 2013, inclusive.      |
 | `month:AAAA-MM:N` | N months        | `'month:2010-04:3'` | The three months from April to June 2010.        | From the 1st of April 2010 to the 30th of June 2010, inclusive.       |
+| `day:AAAA-MM-DD:N` | N days        | `'day:2010-04-01:30'` | The thirty days of April 2010. | From the 1st of April 2010 to the 30th of April 2010, inclusive.       |
 | `ETERNITY` | Forever        | `ETERNITY` | All of time.        | All past, present and future day, month or year|
 
-This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time shows periods' impact on a variable
+This [YAML test](writing_yaml_tests.md) on `income_tax` evolution over time shows periods' impact on a variable:
 
 ```yaml
 
@@ -61,6 +62,7 @@ class salary(Variable):
 Most of the values calculated in OpenFisca, such as `income_tax`, and `housing_allowance`, can change over time.
 
 Therefore, all OpenFisca variables have a `definition_period` attribute:
+  - `definition_period = DAY`: The variable may have a different value each day.
   - `definition_period = MONTH`: The variable may have a different value each month. *For example*, the salary of a person. When `formula` is executed, the parameter `period` will always be a whole month. Trying to compute `salary` with a period that is not a month will raise an error before entering `formula`.
   - `definition_period = YEAR`: The variable is defined for a year or it has always the same value every months of a year. *For example*, if taxes are to be paid yearly, the corresponding variable is yearly. When `formula` is executed, the parameter `period` will always be a whole year (from January 1st to December 31th).
   - `definition_period = ETERNITY`: The value of the variable is constant. *For example*, the date of birth of a person never changes. `period` is still the 2nd parameter of `formula`. However when `formula` is executed, the parameter `period` can be anything and it should not be used.

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -58,8 +58,9 @@ The previous example could also be defined as:
 
 ```py
 from openfisca_core import periods
+from openfisca_core.model_api import MONTH
 
-period_2015 = periods.Period(('month', periods.Instant((2015, 1, 1)), 12))
+period_2015 = periods.Period((MONTH, periods.Instant((2015, 1, 1)), 12))
 ```
 
 ## Periods in variable definitions

--- a/source/key-concepts/periodsinstants.md
+++ b/source/key-concepts/periodsinstants.md
@@ -13,11 +13,11 @@ _Example: the 15th June 2015._
 _Example: a month ("July 2015"), a year ("2015"), several months ("July and August 2015") or the eternity._
 
 
-The smallest unit for OpenFisca periods is the **month**. Therefore:
+The smallest unit for OpenFisca periods is the **day**. Therefore:
 
 - All periods are presumed to start on the first day of their first month.
-- A period cannot be smaller than a month.
+- A period cannot be smaller than a day.
 
 The largest unit for OpenFisca periods is the **eternity**, which is used for variables that are constant over time, e.g. a date of birth.
 
-[Read more about the periods implementation in OpenFisca](../coding-the-legislation/35_periods.md)
+[Read more about the periods implementation in OpenFisca](../coding-the-legislation/35_periods.md).

--- a/source/key-concepts/periodsinstants.md
+++ b/source/key-concepts/periodsinstants.md
@@ -4,20 +4,18 @@ Most of the values calculated in OpenFisca, such as an _income tax_, or a _housi
 
 In [simulations](simulation.md), parameters and variables, OpenFisca handles time via *periods* and *instants*.
 
-- *Instant*: the atomic unit is a day, so instants are day dates.
+In OpenFisca context, a period consists of:
+- a starting instant (the atomic unit is a day, so instants are day dates),
+- a unit (day, month or year),
+- a quantity of that unit.
 
-_Example: the 15th June 2015._
+Let's look at some examples:
+* here is an instant: the 15th June 2015,
+* and here are some periods: `July 2015` is a month starting on its 1st day, `2015` is a year starting on its 1st day, 
+* we can also define a period of several months, `July and August 2015`, or a period overlapping different months, `one month starting on the 15th of July`.
 
-- *Period*: a succession of days.
+The smallest unit for OpenFisca periods is the **day**.
 
-_Example: a month ("July 2015"), a year ("2015"), several months ("July and August 2015") or the eternity._
-
-
-The smallest unit for OpenFisca periods is the **day**. Therefore:
-
-- All periods are presumed to start on the first day of their first month.
-- A period cannot be smaller than a day.
-
-The largest unit for OpenFisca periods is the **eternity**, which is used for variables that are constant over time, e.g. a date of birth.
+The largest OpenFisca period is the **eternity**, which is used for variables that are constant over time, e.g. a date of birth.
 
 [Read more about the periods implementation in OpenFisca](../coding-the-legislation/35_periods.md).


### PR DESCRIPTION
Fixes #191 

* Add a python example on time range syntax
* Add python example on link between Period and Instant (and string)
* Reorganise periods description between `key concepts` and `from law to code` sections