### PR TITLE
Remove outdated statement about project

### DIFF
--- a/source/key-concepts/index.md
+++ b/source/key-concepts/index.md
@@ -27,4 +27,4 @@ Last sections present different **applications** of OpenFisca.
    * [Simulation, Computation](simulation.md)
    * [Reforms](reforms.md)
 
-We use the French legislation to illustrate these concepts as it is the only actively maintained country for now. French names are kept as it is.
+We use the French legislation to illustrate these concepts. French names are kept as it is.


### PR DESCRIPTION
Hello!

This removes a clause in the concepts index saying that France is the only actively maintained country, which is no longer true, and might give people the wrong impression about the project.

I don't think it's necessary to replace it with another justification.

