### PR TITLE
Fix API calculate example

### DIFF
--- a/source/openfisca-web-api/input-output-data.md
+++ b/source/openfisca-web-api/input-output-data.md
@@ -95,18 +95,18 @@ The time period must respect the [definition period](../coding-the-legislation/3
         "Janet"
       ],
       "housing_occupancy_status": {
-        "2016-01": "Tenant",
-        "2016-02": "Tenant",
-        "2016-03": "Owner",
-        "2016-04": "Owner",
-        "2016-05": "Owner",
-        "2016-06": "Owner",
-        "2016-07": "Owner",
-        "2016-08": "Owner",
-        "2016-09": "Owner",
-        "2016-10": "Owner",
-        "2016-11": "Owner",
-        "2016-12": "Owner"
+        "2016-01": "tenant",
+        "2016-02": "tenant",
+        "2016-03": "owner",
+        "2016-04": "owner",
+        "2016-05": "owner",
+        "2016-06": "owner",
+        "2016-07": "owner",
+        "2016-08": "owner",
+        "2016-09": "owner",
+        "2016-10": "owner",
+        "2016-11": "owner",
+        "2016-12": "owner"
       },
       "accommodation_size": {
         "2016-01": 57,
@@ -177,20 +177,20 @@ To indicate you want a variable computed, insert the variable in the correspondi
         "Janet"
       ],
       "housing_occupancy_status": {
-        "2016-01": "Tenant",
-        "2016-02": "Tenant",
-        "2016-03": "Owner",
-        "2016-04": "Owner",
-        "2016-05": "Owner",
-        "2016-06": "Owner",
-        "2016-07": "Owner",
-        "2016-08": "Owner",
-        "2016-09": "Owner",
-        "2016-10": "Owner",
-        "2016-11": "Owner",
-        "2016-12": "Owner"
+        "2016-01": "tenant",
+        "2016-02": "tenant",
+        "2016-03": "owner",
+        "2016-04": "owner",
+        "2016-05": "owner",
+        "2016-06": "owner",
+        "2016-07": "owner",
+        "2016-08": "owner",
+        "2016-09": "owner",
+        "2016-10": "owner",
+        "2016-11": "owner",
+        "2016-12": "owner"
       },
-      "accomodation_size": {
+      "accommodation_size": {
         "2016-01": 57,
         "2016-02": 57,
         "2016-03": 57,
@@ -217,61 +217,8 @@ To indicate you want a variable computed, insert the variable in the correspondi
 The API will return an identical JSON file where all the `null` (the variable that you asked OpenFisca to compute, see above for details) have been replace by the computed value.
 ```json
 {
-  "households": {
-    "household_1": {
-      "parents": [
-        "Ricarda",
-        "Bob"
-      ]
-    },
-    "household_2": {
-      "accomodation_size": {
-        "2016-01": 57,
-        "2016-02": 57,
-        "2016-03": 57,
-        "2016-04": 57,
-        "2016-05": 57,
-        "2016-06": 57,
-        "2016-07": 57,
-        "2016-08": 57,
-        "2016-09": 57,
-        "2016-10": 57,
-        "2016-11": 57,
-        "2016-12": 57
-      },
-      "children": [
-        "Janet"
-      ],
-      "housing_occupancy_status": {
-        "2016-01": "Tenant",
-        "2016-02": "Tenant",
-        "2016-03": "Owner",
-        "2016-04": "Owner",
-        "2016-05": "Owner",
-        "2016-06": "Owner",
-        "2016-07": "Owner",
-        "2016-08": "Owner",
-        "2016-09": "Owner",
-        "2016-10": "Owner",
-        "2016-11": "Owner",
-        "2016-12": "Owner"
-      },
-      "housing_tax": {
-        "2016": 570.0
-      },
-      "parents": [
-        "Bill"
-      ]
-    }
-  },
   "persons": {
-    "Bill": {},
-    "Bob": {},
-    "Janet": {},
     "Ricarda": {
-      "income_tax": {
-        "2016-06": 525.0
-      },
       "salary": {
         "2016-01": 3500,
         "2016-02": 3500,
@@ -285,6 +232,59 @@ The API will return an identical JSON file where all the `null` (the variable th
         "2016-10": 4000,
         "2016-11": 4000,
         "2016-12": 4000
+      },
+      "income_tax": {
+        "2016-06": 525
+      }
+    },
+    "Bob": {},
+    "Bill": {},
+    "Janet": {}
+  },
+  "households": {
+    "household_1": {
+      "parents": [
+        "Ricarda",
+        "Bob"
+      ]
+    },
+    "household_2": {
+      "parents": [
+        "Bill"
+      ],
+      "children": [
+        "Janet"
+      ],
+      "housing_occupancy_status": {
+        "2016-01": "tenant",
+        "2016-02": "tenant",
+        "2016-03": "owner",
+        "2016-04": "owner",
+        "2016-05": "owner",
+        "2016-06": "owner",
+        "2016-07": "owner",
+        "2016-08": "owner",
+        "2016-09": "owner",
+        "2016-10": "owner",
+        "2016-11": "owner",
+        "2016-12": "owner"
+      },
+      "accommodation_size": {
+        "2016-01": 57,
+        "2016-02": 57,
+        "2016-03": 57,
+        "2016-04": 57,
+        "2016-05": 57,
+        "2016-06": 57,
+        "2016-07": 57,
+        "2016-08": 57,
+        "2016-09": 57,
+        "2016-10": 57,
+        "2016-11": 57,
+        "2016-12": 57
+      },
+      "housing_tax": {
+        "2016": 570
       }
     }
   }


### PR DESCRIPTION
Running the calculate endpoint [example](https://openfisca.org/doc/openfisca-web-api/input-output-data.html) on the web API raises a :

-  `400` for  `Error: BAD REQUEST` 

```{
  "households": {
    "household_2": {
      "housing_occupancy_status": {
        "2016-01": "'Tenant' is not a known value for 'housing_occupancy_status'. Possible values are ['owner', 'tenant', 'free_lodger', 'homeless']."
      }
    }
  }
}
```
And then:

- `404`for ` Error: NOT FOUND`
```
{
  "households": {
    "household_2": {
      "accomodation_size": "You tried to calculate or to set a value for variable 'accomodation_size', but it was not found in the loaded tax and benefit system (openfisca-country-template@3.9.6). Are you sure you spelled 'accomodation_size' correctly? If this code used to work and suddenly does not, this is most probably linked to an update of the tax and benefit system. Look at its changelog to learn about renames and removals and update your code. If it is an official package, it is probably available on <https://github.com/openfisca/openfisca-country-template/blob/master/CHANGELOG.md>."
    }
  }
}
```

Fixed based on the [3.0.0](https://github.com/openfisca/country-template/blob/master/CHANGELOG.md#300---34) version update of country-template.