### PR TITLE
Document reforms in YAML tests

### DIFF
--- a/source/coding-the-legislation/legislation_parameters.md
+++ b/source/coding-the-legislation/legislation_parameters.md
@@ -281,7 +281,7 @@ And then to get `parameters(period).housing_benefit.amount_by_zone[zone]`
 
 ## How to navigate the parameters in Python
 
-Set-up your python file by importing a `country package` and building the `tax and benefits system`
+Set-up your python file by importing a `country package` and building the `tax and benefit system`
 
 > Example :
 > ```

--- a/source/coding-the-legislation/writing_yaml_tests.md
+++ b/source/coding-the-legislation/writing_yaml_tests.md
@@ -28,8 +28,9 @@ In [`irpp.yaml`](https://github.com/openfisca/openfisca-france/blob/29.3.7/tests
 - `description` (string, optional, multiline)
 - `absolute_error_margin` (number, optional)
 - `relative_error_margin` (number, optional)
-- `input_variables` (associative array, keys are variable names, values are numbers)
-- `output_variables` (associative array, keys are variable names, values are numbers)
+- `input` (associative array, keys are variable names, values are numbers)
+- `output` (associative array, keys are variable names, values are numbers)
+- `reforms` (list of openfisca reform modules to be applied to the baseline tax-benefit system)
 - other any key defined in the model
 
 ## Syntax
@@ -52,7 +53,7 @@ This is the simplest way to test formulas when you only need to give input value
   absolute_error_margin: 0.5
 ```
 
-- Create nested dictionnaries within the keys `input_variables` and `output_variables`,
+- Create nested dictionnaries within the keys `input` and `output`,
 which keys are variable names and values are numbers, respectively input and expected values.
 For instance:
 
@@ -73,54 +74,59 @@ For instance:
 This is the simplest way to test formulas when you need to give input values for many individuals
 which are dispatched into entities.
 
-> See the last test of [cotisations_sociales_simulateur_IPP.yaml](https://github.com/openfisca/openfisca-france/blob/29.3.7/tests/cotisations_sociales_simulateur_IPP.yaml#L244-L303)
+> See the last test of [cotisations_sociales_simulateur_IPP.yaml](https://github.com/openfisca/openfisca-france/blob/221147983dabb7d3971b7f1ed86d44346fca449a/tests/cotisations_sociales_simulateur_IPP.yaml#L186-244)
 
 In this case, there is another convention:
 
-- do not include the field `input_variables` but instead define new keys corresponding to the entities:
+- do not include the variables directly as keys of the `input` but instead define new keys corresponding to the entities:
 
     ```yaml
     - name: "IRPP - Famille ayant des revenus salariaux de 20 000 €"
-    period: 2012
-    absolute_error_margin: 0.5
-    input:
-      familles:
-      menages:
-      foyers_fiscaux:
+      period: 2012
+      absolute_error_margin: 0.5
+      input:
+        individus:
+          # ...
+        familles:
+          # ...
+        menages:
+          # ...
+        foyers_fiscaux:
+          # ...
     ```
 
 - define the individuals with their `id` and their variables:
 
     ```yaml
-    individus:
-      parent1:
-        date_naissance: 1972-01-01
-        depcom_entreprise: "69381"
-        primes_fonction_publique: 500
-      parent2:
-        date_naissance: 1972-01-01
-        depcom_entreprise: "69381"
-        primes_fonction_publique: 500
-        traitement_indiciaire_brut: 2000
-      enfant1:
-        date_naissance: 2000-01-01
-      enfant2:
-        date_naissance: 2009-01-01
+      individus:
+        parent1:
+          date_naissance: 1972-01-01
+          depcom_entreprise: "69381"
+          primes_fonction_publique: 500
+        parent2:
+          date_naissance: 1972-01-01
+          depcom_entreprise: "69381"
+          primes_fonction_publique: 500
+          traitement_indiciaire_brut: 2000
+        enfant1:
+          date_naissance: 2000-01-01
+        enfant2:
+          date_naissance: 2009-01-01
     ```
 
 - specify the relations between individuals and their entity:
 
     ```yaml
-    familles:
-        parents: ["parent1", "parent2"]
-        enfants: ["enfant1", "enfant2"]
-    menages:
-        personne_de_reference: "parent1"
-        conjoint: "parent2"
-        enfants: ["enfant1", "enfant2"]
-    foyers_fiscaux:
-        declarants: ["parent1", "parent2"]
-        personnes_a_charge: ["enfant1", "enfant2"]
+      familles:
+          parents: ["parent1", "parent2"]
+          enfants: ["enfant1", "enfant2"]
+      menages:
+          personne_de_reference: "parent1"
+          conjoint: "parent2"
+          enfants: ["enfant1", "enfant2"]
+      foyers_fiscaux:
+          declarants: ["parent1", "parent2"]
+          personnes_a_charge: ["enfant1", "enfant2"]
     ```
 
 - (specifying all entities is not mandatory; for any entity that is not specified, all individuals are assumed to be "a group of their own"; that is, if you do not specify any families, OpenFisca assumes that each individual is the lone member of a one-person family; this applies for Web API payloads as well as test cases)
@@ -145,6 +151,17 @@ Values can be arithmetic expressions too.
       2013-01: 35 * 52 / 12 * 9
       2013-02: 35 * 52 / 12 * 9
       2013-03: 35 * 52 / 12 * 9
+```
+
+### Testing a variable using a reform
+
+[Reforms](./reforms.md) can be applied to the baseline tax and benefit system as a list to the reforms key.
+
+```yaml
+- name: "Combination of 2 reforms"
+  reforms:
+    - module.of.first_reform
+    - module.of.second_reform
 ```
 
 ## Running a test

--- a/source/contribute/variables-naming.md
+++ b/source/contribute/variables-naming.md
@@ -6,7 +6,7 @@ General philosophy
 
 The discussion below is concerned with naming the variables of a country package. In that case, the ["local language rule"](language.md) applies, and the appropriate language for modeling the domain is one of the native ones of the modeled country. We consider each tax, collecting organism and country regulation, and so on, as a domain-specific term. In the same fashion, well-known abbreviations of these domain-specific terms are accepted.
 
-OpenFisca variables names should, as much as possible, be understandable by an external contributor who is **curious** about the country's tax and benefits system, **without necessarily being an expert**.
+OpenFisca variables names should, as much as possible, be understandable by an external contributor who is **curious** about the country's tax and benefit system, **without necessarily being an expert**.
 
 One should be able to get a rough idea of the meaning of a variable by reading its name, or by quickly researching it on the web.
 

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -17,7 +17,7 @@ For tax and benefit systems models, the following conventions are applied:
 
 - Channels that centralise discussions around a specific tax and benefit system are given the name of the distributed module, suffixed by `-system`. _For example: `france-system`_. If that full name is too long for the Slack channel character limit, then a shortened version of the name is used.
 - Channels that centralise discussions around extensions to tax and benefit systems are given that system’s module name, followed by `-ext-` and an identifier for that extension. _For example: `france-ext-paris`_.
-- System-specific group channels are campfires around which some specific organisations of contributors to a tax and benefits system gather. When a country becomes large enough, it often happens that several employers of contributors work concurrently on different parts of the system, and the main `-system` channel would become unreadable. These channels are called that system’s module name, followed by `-org-` and an identifier for that group. _For example: `france-org-gouv`_.
+- System-specific group channels are campfires around which some specific organisations of contributors to a tax and benefit system gather. When a country becomes large enough, it often happens that several employers of contributors work concurrently on different parts of the system, and the main `-system` channel would become unreadable. These channels are called that system’s module name, followed by `-org-` and an identifier for that group. _For example: `france-org-gouv`_.
 
 ## Contact
 

--- a/source/index.md
+++ b/source/index.md
@@ -2,7 +2,7 @@
 
 [OpenFisca](https://www.openfisca.org) is an open source platform to write rules as code.
 
-Describe your tax & benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
+Describe your tax and benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
 
 * **For economists**: OpenFisca allows you to use survey data to simulate the impact of a  reform on a given government’s budget and on a population’s standard of living.
 * **For developers**: OpenFisca allows you to easily create web applications based on your simulation results, thanks to the web API. You can build a great variety of other services by coding formulas, hosting your own instance or building your own extensions.
@@ -10,7 +10,7 @@ Describe your tax & benefit system, provide a situation as input (i.e income), a
 
 ## How does OpenFisca work?
 
-### 1 - Choose an available tax & benefit system or roll your own:
+### 1 - Choose an available tax and benefit system or roll your own:
 
 With OpenFisca, you can:
 * Use an existing tax and benefit system (see the [list of systems already built](https://openfisca.org/en/countries/))

--- a/source/installation/test_situations.md
+++ b/source/installation/test_situations.md
@@ -1,6 +1,6 @@
 # How to test your changes on "ready to use" situations (for OpenFisca-France)
 
-Often, when making changes to legislation, you need to test it on a situation that works with your country Tax & Benefit system.
+Often, when making changes to legislation, you need to test it on a situation that works with your country tax and benefit system.
 Sometimes, these situations can be quite complicated to model (such as roomates).
 Instead of re-writing them everytime, we have pre-packaged a few in a Python Package.
 

--- a/source/simulate/run-simulation.md
+++ b/source/simulate/run-simulation.md
@@ -1,7 +1,7 @@
 # How to run a simulation
 
 To calculate some legislation variables on people's situations, you need to create and run a new *Simulation*. Whether situations are described with [test cases](run-simulation.md#test-cases) or [data](run-simulation.md#data), OpenFisca looks for two kinds of inputs:
-- how persons are dispatched in other entities, 
+- how persons are dispatched in other entities,
 - what variables' values are already known.
 
 ## How to run a simulation on a test case
@@ -10,8 +10,8 @@ Test cases can be expressed in Python, or in JSON when using the Web API (see th
 
 ### Test cases
 
-A test case describes persons and other entities with their variables values.  
-It's the usual solution to define a small number of situations. 
+A test case describes persons and other entities with their variables values.
+It's the usual solution to define a small number of situations.
 
 Here is an example of test case (in Python):
 
@@ -41,14 +41,14 @@ TEST_CASE = {
     'persons': {
         'Ari': {
             'salary': {'2011-01': 1000}
-        }, 
-        'Paul': {}, 
-        'Leila': {}, 
+        },
+        'Paul': {},
+        'Leila': {},
         'Javier': {}
     },
     'households': {
         'h1': {
-            'children': ['Leila'], 
+            'children': ['Leila'],
             'parents': ['Ari', 'Paul'],
             'rent': {'2011-01': 300}
         },
@@ -67,7 +67,7 @@ It's a Python dictionary object that we will use to build a *Simulation*.
 
 Let's assume that you want to calculate households' `housing_allowance` for the same period.
 You have to follow these steps:
-1. Load a tax and benefits system like [OpenFisca-Country-Template](https://demo.openfisca.org/legislation).
+1. Load a tax and benefit system like [OpenFisca-Country-Template](https://demo.openfisca.org/legislation).
 2. Initialise a *SimulationBuilder*.
 3. Create a *Simulation* using, for example, the `build_from_entities(...)` function.
 4. Calculate the [housing_allowance](https://demo.openfisca.org/legislation/housing_allowance) and print its value for every test case household.
@@ -131,10 +131,10 @@ As for the *test case* content, you will need the following information:
   > like `person_id` and `household_id` columns information in the CSV example
 - if you have multiple [entities](../key-concepts/person,_entities,_role.md) types (persons, households, ...), you need to know how your persons list is dispatched over your *group entities*
   > in CSV example, every `person_id` is associated with a `household_id` on the same line
-- the name of the corresponding variable in your model for every set of values 
+- the name of the corresponding variable in your model for every set of values
   > `person_salary` values become [salary](https://demo.openfisca.org/legislation/salary) values in `OpenFisca-Country-Template` model
 - the period and entity for every set of values
-  > `person_salary` and `person_age` belong to *Person* entity  
+  > `person_salary` and `person_age` belong to *Person* entity
   > the reference period isn't in the CSV file but it might, for example, come from the CSV creation time and be identical for the whole data set.
 
 
@@ -203,7 +203,7 @@ In the following example, we will use the [pandas](https://pandas.pydata.org) li
     ```
 
 3. Build a simulation according to your data's length with `SimulationBuilder` and configure the simulation:
-   
+
     ```python
     from openfisca_core.simulation_builder import SimulationBuilder
     import numpy
@@ -235,7 +235,7 @@ And, persons' order is kept:
 >>> print(data.person_id.values)
 
 array([ 1  2  3  4  5  6  7 12  8  9 10 11])
-``` 
+```
 
 Thus, you can get the calculated `income_tax` of one person. For example, get its value for the 8th person in the list with:
 ```python
@@ -248,7 +248,7 @@ Thus, you can get the calculated `income_tax` of one person. For example, get it
 
 In this example, we will manage `persons` and `households` entities. To calculate households' `total_taxes`, we include persons' `income_tax`. So, we need to link the persons list to the households and define their roles.
 
-Let's say that our persons and households lists are defined in distinct files: 
+Let's say that our persons and households lists are defined in distinct files:
 
 * `data_persons.csv`
     ```
@@ -306,7 +306,7 @@ where `household_id` is used as pivot item linking these files contents.
     ```
 
 3. Initialise a simulation builder with the `Person` entity. All you need is the list of persons identifiers:
-   
+
     ```python
     from openfisca_core.simulation_builder import SimulationBuilder
     import numpy as numpy
@@ -328,7 +328,7 @@ where `household_id` is used as pivot item linking these files contents.
     # Instanciate the household entity:
     households_ids = data_households.household_id
     household_instance = sb.declare_entity('household', households_ids)
-    
+
     # Join households data on persons:
     persons_households = data_persons.household_id
     persons_households_roles = data_persons.person_role_in_household


### PR DESCRIPTION
Document reforms in YAML tests
Remove mention of input_variable and output_variable
Use tax and benefit system everywhere

Fix #185
Fix #249 