### PR TITLE
Fix sphinx error at tests execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --editable git+https://github.com/openfisca/openfisca-core.git@master#egg=OpenFisca-Core[dev]
 docutils==0.13.1
 guzzle_sphinx_theme==0.7.11
+jinja2<3.1.0
 recommonmark==0.4
 sphinx-autobuild==0.7.1
 sphinx-markdown-tables==0.0.9


### PR DESCRIPTION
Fixes the `Extension error:
Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/.../virtualenvs/doc-install/lib/python3.7/site-packages/jinja2/__init__.py))` raised at `make test`.


**Additional information**
`make test` was executed in a virtual environment after `make install`.


