### PR TITLE
Remove feedback button

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -17,5 +17,4 @@
 
 <!-- Page content footer -->
 {%- block bottom_rel_links %}
-  <a class="actionbutton" title="Did you find what you were looking for?" data-toggle="tooltip" data-placement="top"  href="https://openfisca.typeform.com/to/WudIsQ"><i class="fas fa-question"></i></a>
 {%- endblock %}

--- a/source/static/scripts.js
+++ b/source/static/scripts.js
@@ -23,6 +23,4 @@ $(document).ready(function() {
 
   $('a[href^="https://"], a[href^="http://"]').attr("target", "_blank"); // Make all external links open in a new Window
 
-  // Activate action button tooltip
-  $('.actionbutton').tooltip()
 });

--- a/source/static/style.css
+++ b/source/static/style.css
@@ -7,26 +7,6 @@
   font-family: 'asapregular';
 }
 
-.actionbutton{
-  border-radius: 30px;
-  width: 56px;
-  height: 56px;
-  background: #6D69FB;
-  color: #ffffff;
-  text-align: center;
-  bottom: 2rem;
-  right: 2rem;
-  position: fixed;
-  cursor: pointer;
-  box-shadow: 5px 5px 5px grey;
-  font-size: 1.5em;
-  padding: 15px;
-}
-.actionbutton:hover{
-  color: #ffffff;
-}
-
-
 .button-appearance {
   text-decoration: none;
   border: #6D69FB 1px solid;


### PR DESCRIPTION
This changeset removes the floating feedback button that misleadingly looks like a “get help” button, always floating in the lower left corner of the documentation.

<img width="208" alt="Capture d’écran 2022-04-29 à 16 39 28" src="https://user-images.githubusercontent.com/222463/165955634-ae243e4a-19a4-4d2f-a83d-ac5b61460c4a.png">

### Rationale

1. No team actively monitors responses. Actually, until today, no maintainer knew the password to access the service collecting replies.
2. It is misleading. The drop rate (people clicking on it vs people leaving feedback) is 93% (4-to-60).
3. In 3 years, this form collected 4 responses, of which only 1 was useful, in 2019. It mentioned broken links, detection of which should be automated. All responses are given below.

| Date        | Time  | Type | Comment |
|-------------|-------|---------------------------------------------------------------------------------------|--------------------------------------------------|
| 18 Jan 2022 | 18:57 | I didn't find what I was looking for                                                  | No                                               |   |
| 10 May 2021 | 17:09 | I didn't find what I was looking for                                                  | [email hidden] simulation droit aide au logement |   |
| 19 Jan 2020 | 13:49 | I think there is a mistake                                                            | g                                                |   |
| 3 Dec 2019  | 09:33 | Section 3 of https://openfisca.org/doc/ , the web-api and python api links are broken | [email hidden]                                   |   |