### PR TITLE
Unify casings and punctuation

### DIFF
--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -89,7 +89,7 @@ class taxes(Variable):
 
 However, sometimes, we do need to estimate a variable for a different period than the one it is defined for.
 
-We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells openfisca to split the period into months, compute the variable for each month and sum up the results:
+We may for example want to get the sum of the salaries perceived on the past year, or the past 3 months. The option `ADD` tells OpenFisca to split the period into months, compute the variable for each month and sum up the results:
 
 ```py
 class taxes(Variable):

--- a/source/coding-the-legislation/40_legislation_evolutions.md
+++ b/source/coding-the-legislation/40_legislation_evolutions.md
@@ -1,6 +1,6 @@
 # Legislation evolutions
 
-Openfisca handles the fact that the legislation changes over time.
+OpenFisca handles the fact that the legislation changes over time.
 
 ## Parameter evolution
 

--- a/source/coding-the-legislation/writing_yaml_tests.md
+++ b/source/coding-the-legislation/writing_yaml_tests.md
@@ -144,7 +144,7 @@ In this case, there is another convention:
           personnes_a_charge: ["enfant1", "enfant2"]
     ```
 
-- Specifying all entities is not mandatory. For any entity that is not specified, all individuals are assumed to be in "a group of their own". Which means if you do not specify any families, OpenFisca assumes that each individual is the lone member of a one-person family. This applies to Web API payloads as well as test cases.
+- Specifying all entities is not mandatory. For any entity that is not specified, all individuals are assumed to be in "a group of their own". Which means if you do not specify any families, OpenFisca assumes that each individual is the lone member of a one-person family. This applies to web API payloads as well as test cases.
 
 - Finally, define a dictionary of the expected values of the output variables. Each output variable takes a list of length equal to the number of individuals defined in the test. E.g, for a family of four individuals with two working parents and two unemployed children, the output variable salaire_super_brut is defined as follows:
 

--- a/source/contribute/commit-messages.md
+++ b/source/contribute/commit-messages.md
@@ -5,7 +5,7 @@ Commit messages
 Variable name changes
 ---------------------
 
-To avoid Openfisca users to be surprised by a non expected variable renaming breaking their code, we use standard commit messages when renaming a variable. The syntax is formalized below. It must be respected precisely, to allow automatic information extraction.
+To avoid OpenFisca users to be surprised by a non expected variable renaming breaking their code, we use standard commit messages when renaming a variable. The syntax is formalized below. It must be respected precisely, to allow automatic information extraction.
 
 
 ### Renaming

--- a/source/contribute/semver.md
+++ b/source/contribute/semver.md
@@ -1,7 +1,7 @@
 Semantic versionning guidelines
 ===============================
 
-Before merging your contribution to an openfisca package, you are required to increment the version of this package.
+Before merging your contribution to an OpenFisca package, you are required to increment the version of this package.
 
 The [semantic versionning convention](http://semver.org/), applied here, requires you to:
 
@@ -14,9 +14,9 @@ The [semantic versionning convention](http://semver.org/), applied here, require
 
 >**PATCH** version when you make backwards-compatible bug fixes.
 
-It is thus crucial to determine whether your changes are **backwards-compatible**. If, during a hackathon, a contributor has written a reform to Openfisca, would this reform still work after adding your changes ?
+It is thus crucial to determine whether your changes are **backwards-compatible**. If, during a hackathon, a contributor has written a reform to OpenFisca, would this reform still work after adding your changes ?
 
-Examples in Openfisca context
+Examples in OpenFisca context
 -----------------------------
 
 ### Country package (e.g. openfisca-france)

--- a/source/index.md
+++ b/source/index.md
@@ -10,7 +10,7 @@ Describe your tax and benefit system, provide a situation as input (i.e income),
 
 ## How does OpenFisca work?
 
-### 1 - Choose an available tax and benefit system or roll your own:
+### 1 - Choose an available tax and benefit system or roll your own
 
 With OpenFisca, you can:
 * Use an existing tax and benefit system (see the [list of systems already built](https://openfisca.org/en/countries/))
@@ -44,7 +44,7 @@ Also, there are tons of libraries to help you illustrate your results ([plot.ly]
 
 Please make sure you read our [licence information](licence.md) before using results based on OpenFisca.
 
-## Things OpenFisca won’t do for you:
+## Things OpenFisca won’t do for you
 
 * Behaviour-based analysis. OpenFisca is a static micro-simulation model, so it will provide you with results “as-of-tomorrow” (i.e. a new tax bracket won’t affect consumption).
 * OpenFisca is contributive: if the legislation you need is not described yet, you’re the best person to add it (take a look at our [contribution guidelines](contribute/index.md)).

--- a/source/key-concepts/person,_entities,_role.md
+++ b/source/key-concepts/person,_entities,_role.md
@@ -4,7 +4,7 @@ Taxes and benefits can be calculated for different entities: persons, household,
 
 ## Person
 
-Some openfisca variables are defined for a *person*.
+Some OpenFisca variables are defined for a *person*.
 
 Example: a ["salary"](https://fr.openfisca.org/legislation/salaire_net) is defined as the individual level.
 

--- a/source/openfisca-python-api/index.md
+++ b/source/openfisca-python-api/index.md
@@ -1,4 +1,4 @@
-# <i class="fab fa-python"></i> Openfisca Python API
+# <i class="fab fa-python"></i> OpenFisca Python API
 
 
 Modules:

--- a/source/openfisca-web-api/config-openapi.md
+++ b/source/openfisca-web-api/config-openapi.md
@@ -1,6 +1,6 @@
 # OpenAPI specification configuration
 
-The OpenFisca Web API exposes a `/spec` route that documents how to use the API, using the OpenAPI standard.
+The OpenFisca web API exposes a `/spec` route that documents how to use the API, using the OpenAPI standard.
 
 Most the the `/spec` content is automatically built for you. However, some minimal configuration can make the provided examples more complete and relevant, and improve the [Swagger interactive documentation packaged in the Legislation Explorer](http://demo.openfisca.org/legislation/swagger).
 
@@ -18,6 +18,6 @@ This configuration is done in the initialisation of your `TaxBenefitSystem`. For
 This defines:
   - `variable_example`: A variable of your model that you want to appear in the specification. Usually a well known variable (e.g. salary).
   - `parameter_example`: A parameter of your model that you want to appear in the specification. Usually a well known variable (e.g. minimum wage).
-  - `simulation_example`: A Python `dict` representing a JSON that could be sent to the Web API. It should include some input values, and some values set to `null`/`None` so that they are calculated.
+  - `simulation_example`: A Python `dict` representing a JSON that could be sent to the web API. It should include some input values, and some values set to `null`/`None` so that they are calculated.
 
 Note that if no OpenAPI configuration is provided, an arbitrary variable and an arbitrary parameter will be used, and no simulation example will be provided as an example.

--- a/source/openfisca-web-api/endpoints.md
+++ b/source/openfisca-web-api/endpoints.md
@@ -3,7 +3,7 @@
 Each OpenFisca Country Package web API comes with a set of endpoints including an OpenAPI specification on the `/spec` route.
 You can check out the demonstration [swagger documentation](http://demo.openfisca.org/legislation/swagger) to see how the endpoints work.
 
-The OpenFisca Web API can be used to:
+The OpenFisca web API can be used to:
  - access information about the parameters (e.g. `/parameters`), the variables (e.g. `/variables`), and entities (e.g. `/entities`) of the Country Package,
- - run simulations (e.g. `/calculate`) on a specific situation. To describe a situation, learn more about the Web API [inputs and outputs](input-output-data.md),
+ - run simulations (e.g. `/calculate`) on a specific situation. To describe a situation, learn more about the web API [inputs and outputs](input-output-data.md),
  - analyse a simulation calculation (e.g. `/trace`) on a specific situation.

--- a/source/openfisca-web-api/endpoints.md
+++ b/source/openfisca-web-api/endpoints.md
@@ -3,7 +3,7 @@
 Each OpenFisca Country Package web API comes with a set of endpoints including an OpenAPI specification on the `/spec` route.
 You can check out the demonstration [swagger documentation](http://demo.openfisca.org/legislation/swagger) to see how the endpoints work.
 
-The Openfisca Web API can be used to:
+The OpenFisca Web API can be used to:
  - access information about the parameters (e.g. `/parameters`), the variables (e.g. `/variables`), and entities (e.g. `/entities`) of the Country Package,
  - run simulations (e.g. `/calculate`) on a specific situation. To describe a situation, learn more about the Web API [inputs and outputs](input-output-data.md),
  - analyse a simulation calculation (e.g. `/trace`) on a specific situation.

--- a/source/openfisca-web-api/index.md
+++ b/source/openfisca-web-api/index.md
@@ -1,4 +1,4 @@
-# <i class="fas fa-cloud"></i> OpenFisca Web API
+# <i class="fas fa-cloud"></i> OpenFisca web API
 
 ```{toctree}
 :hidden:
@@ -16,11 +16,11 @@ Using a web interface, app developers can access information and computations wi
 
 The latest version of the France web API is [`api.fr.openfisca.org/latest`](https://api.fr.openfisca.org/latest). Its endpoints are documented in [`fr.openfisca.org/legislation/swagger`](https://fr.openfisca.org/legislation/swagger). This API is provided for prototyping purposes only: it has no SLA (service level agreement, i.e. guarantee of availability) and is kept up to date automatically, with no regard for breaking changes. No support will be provided for this instance. You should not build production systems on top of it.
 
-Anyone wanting a stable OpenFisca Web API is invited to [host their own](#hosting-an-api-instance).
+Anyone wanting a stable OpenFisca web API is invited to [host their own](#hosting-an-api-instance).
 
 ## Use Cases
 
-The following services use the OpenFisca Web API:
+The following services use the OpenFisca web API:
 
 - [fr.openfisca.org/legislation](https://fr.openfisca.org/legislation), giving you information on available OpenFisca variables.
 - [Mes Aides](https://mes-aides.gouv.fr), the French social benefits simulator.

--- a/source/openfisca-web-api/input-output-data.md
+++ b/source/openfisca-web-api/input-output-data.md
@@ -2,7 +2,7 @@
 
 > All the examples provided here are from the [country package template](https://github.com/openfisca/country-template).
 
-In order to run a computation on the Web API, you will need to send information to the API concerning:
+In order to run a computation on the web API, you will need to send information to the API concerning:
 - The situation, meaning describe the [entities](../key-concepts/person,_entities,_role.md) (e.g. individuals, households) that you want to base your calculations on.
 - The variable you need to compute.
 

--- a/source/openfisca-web-api/trace-simulation.md
+++ b/source/openfisca-web-api/trace-simulation.md
@@ -31,7 +31,7 @@ Let's say that you want to calculate the `disposable_income` for one person earn
 }
 ```
 
-If you send this situation to your `country-template` model Web API or try it out on the `/trace` endpoint in the [Swagger interface](https://demo.openfisca.org/legislation/swagger), you get the following response composed of three sections:
+If you send this situation to your `country-template` model web API or try it out on the `/trace` endpoint in the [Swagger interface](https://demo.openfisca.org/legislation/swagger), you get the following response composed of three sections:
 
 * `entitiesDescription`: lists the persons and how they belong to the model group entities,
 * `requestedCalculations`: lists the requested calculations (i.e. variables with values at `null`),

--- a/source/projectcomponents.md
+++ b/source/projectcomponents.md
@@ -6,12 +6,12 @@ OpenFisca is a modular project. Depending on your goals, you will install and in
 
 ## Web API
 
-The Web API lets you access the legislation [Parameters](./key-concepts/parameters.md) and [Variables](./key-concepts/variables.md).
+The web API lets you access the legislation [Parameters](./key-concepts/parameters.md) and [Variables](./key-concepts/variables.md).
 
->**Example**: [Mes Aides](https://mes-aides.gouv.fr) uses the OpenFisca Web API to calculate OpenFisca-France benefits.
+>**Example**: [Mes Aides](https://mes-aides.gouv.fr) uses the OpenFisca web API to calculate OpenFisca-France benefits.
 
-- To explore the OpenFisca-France Web API services, use the [French Legislation Explorer](https://fr.openfisca.org/legislation/)
-- To query the OpenFisca Web API in your app, see the [Web API endpoints description](./openfisca-web-api/endpoints.md)
+- To explore the OpenFisca-France web API services, use the [French Legislation Explorer](https://fr.openfisca.org/legislation/)
+- To query the OpenFisca web API in your app, see the [web API endpoints description](./openfisca-web-api/endpoints.md)
 - To host your own instance of the OpenFisca API, go to the [installation documentation](./openfisca-web-api/index.md)
 
 ## Extensions Packages

--- a/source/projectcomponents.md
+++ b/source/projectcomponents.md
@@ -11,8 +11,8 @@ The Web API lets you access the legislation [Parameters](./key-concepts/paramete
 >**Example**: [Mes Aides](https://mes-aides.gouv.fr) uses the OpenFisca Web API to calculate OpenFisca-France benefits.
 
 - To explore the OpenFisca-France Web API services, use the [French Legislation Explorer](https://fr.openfisca.org/legislation/)
-- To query the Openfisca Web API in your app, see the [Web API endpoints description](./openfisca-web-api/endpoints.md)
-- To host your own instance of the Openfisca API, go to the [installation documentation](./openfisca-web-api/index.md)
+- To query the OpenFisca Web API in your app, see the [Web API endpoints description](./openfisca-web-api/endpoints.md)
+- To host your own instance of the OpenFisca API, go to the [installation documentation](./openfisca-web-api/index.md)
 
 ## Extensions Packages
 
@@ -27,7 +27,7 @@ Extensions add on the capacities of a country-package.
 Country Packages are the basic modules of OpenFisca. They define the [Parameters](./key-concepts/parameters.md), [Entities](./key-concepts/person,_entities,_role.md) and [Variables](./key-concepts/variables.md) of a country.
 
 - To install an existing Country Package, head to that package's documentation.
->**Example**: [Openfisca-france's repository](https://github.com/openfisca/openfisca-france)
+>**Example**: [OpenFisca-france's repository](https://github.com/openfisca/openfisca-france)
 
 
 ## OpenFisca Core

--- a/source/simulate/analyse-simulation.md
+++ b/source/simulate/analyse-simulation.md
@@ -2,7 +2,7 @@
 
 When running a simulation with the Python API, you might want to understand how the result was calculated and what intermediate variables and parameters have been taken into account.
 
-> To trace a simulation calculation with the Web API, please see [/trace endpoint documentation](../openfisca-web-api/trace-simulation.md).
+> To trace a simulation calculation with the web API, please see [/trace endpoint documentation](../openfisca-web-api/trace-simulation.md).
 
 
 ## Activating the simulation tracer

--- a/source/simulate/run-simulation.md
+++ b/source/simulate/run-simulation.md
@@ -6,7 +6,7 @@ To calculate some legislation variables on people's situations, you need to crea
 
 ## How to run a simulation on a test case
 
-Test cases can be expressed in Python, or in JSON when using the Web API (see the [specific section](../openfisca-web-api/input-output-data.md) of the documentation).
+Test cases can be expressed in Python, or in JSON when using the web API (see the [specific section](../openfisca-web-api/input-output-data.md) of the documentation).
 
 ### Test cases
 


### PR DESCRIPTION
Always write “OpenFisca” and “web API”.