### PR TITLE
Improve copywriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFisca Doc
 
-[OpenFisca](http://openfisca.org/doc/) is a versatile microsimulation free software. This repository contains the source code of its [online documentation](http://openfisca.org/doc/).
+[OpenFisca](http://openfisca.org/doc/) is a versatile microsimulation-free software. This repository contains the source code of its [online documentation](http://openfisca.org/doc/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFisca Doc
 
-[OpenFisca](http://openfisca.org/doc/) is a versatile microsimulation-free software. This repository contains the source code of its [online documentation](http://openfisca.org/doc/).
+[OpenFisca](http://openfisca.org/doc/) is versatile and free micro-simulation software. This repository contains the source code of its [online documentation](http://openfisca.org/doc/).
 
 ## Installation
 

--- a/source/_templates/sidebar.html
+++ b/source/_templates/sidebar.html
@@ -1,5 +1,5 @@
 <div class="sphinxsidebar caption">
-    <img src="/_static/img/logo_mini.svg" />
+    <img src="https://cdn.rawgit.com/openfisca/openfisca-doc/master/source/static/img/logo_mini.svg" alt="openfisca logo"/>
     {% include "searchbox.html" %} <!-- Template defined by the guzzle theme-->
 </div>
 

--- a/source/_templates/sidebar.html
+++ b/source/_templates/sidebar.html
@@ -1,5 +1,5 @@
 <div class="sphinxsidebar caption">
-    <img src="https://cdn.rawgit.com/openfisca/openfisca-doc/master/source/static/img/logo_mini.svg" alt="openfisca logo"/>
+    <img src="https://cdn.rawgit.com/openfisca/openfisca-doc/master/source/static/img/logo_mini.svg" alt="OpenFisca"/>
     {% include "searchbox.html" %} <!-- Template defined by the guzzle theme-->
 </div>
 

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -30,9 +30,9 @@ The Core also includes an optional [web API](openfisca-web-api/index.md), which 
 ## Templates
 
 Country and extension packages are maintained by different communities and depend on legal and cultural contexts. OpenFisca provides two templates aimed at demonstrating its capabilities independently:
-[`country-template`](https://github.com/openfisca/country-template/) 
-[`extension-template`](https://github.com/openfisca/extension-template/). 
 
-They can be bootstrapped with a new country or extension package.
-<!--Sentence unclear-->
+- [`country-template`](https://github.com/openfisca/country-template/)
+- [`extension-template`](https://github.com/openfisca/extension-template/)
+
+They can be used as a start for creating a new country or extension package.
 This documentation uses these packages throughout.

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -1,33 +1,38 @@
-# <i class="fas fa-cubes"></i> Architecture
+# <i class="fas fa-cubes"></i> Architecture of OpenFisca
 
 Depending on your goals, you will interact with one or several components of OpenFisca.
 
 [![OpenFisca architecture](https://cdn.rawgit.com/openfisca/openfisca-doc/master/source/static/img/architecture.svg)](https://github.com/openfisca/openfisca-doc/blob/master/source/static/img/architecture.svg)
 
-## Country packages
+## The Country Packages
 
-Country packages are what most users will interact with when using OpenFisca. They model the rules of a jurisdiction by defining [Parameters](key-concepts/parameters.md), [Variables](key-concepts/variables.md) and [Entities](key-concepts/person,_entities,_role.md).
+Country packages are what most users will interact with when using OpenFisca. They model the rules of jurisdiction by defining [Parameters](key-concepts/parameters.md), [Variables](key-concepts/variables.md) and [Entities](key-concepts/person,_entities,_role.md).
 
 > For example, [`openfisca-france`](https://github.com/openfisca/openfisca-france) models French law.
 
-## Extensions packages
+## The Extensions Packages
 
-Extensions add capabilities to a country package while maintaining situation description compatibility by adding or redefining parameters and variables, but not entities.
+Extensions add functionalities to a country package by adding or redefining parameters and variables, but not entities while maintaining situation description compatibility.
 
-This architecture enables subcommunities to maintain subsets of the rules of a country on which they have authority, or which are too specific to be of interest to the wider OpenFisca French community.
+<!--- Needs clarity here----->
+This architecture enables sub-communities to maintain subsets of the rules of a country on which they have the authority, or are too specific to be of interest to the border OpenFisca community.
 
 > For example, [`openfisca-paris`](https://github.com/openfisca/openfisca-paris) extends `openfisca-france` with benefits specific to the town of Paris and is maintained by the Paris City Council.
 
-## Core
+## The Core
 
-OpenFisca Core provides the API, domain-specific language (DSL) and testing tools with which country and extension packages are built.
+OpenFisca Core provides the API, domain-specific language (DSL) and testing tools. The country and extension packages are constructed based on the Core.
 
-It defines the [Python API](openfisca-python-api/index.md) through which the country packages can be queried.
+The core defines the [Python API](openfisca-python-api/index.md) through which the country packages can be queried.
 
 The Core also includes an optional [web API](openfisca-web-api/index.md), which makes it possible to expose [Parameters](key-concepts/parameters.md) and calculate [Variables](key-concepts/variables.md) over HTTP and JSON.
 
 ## Templates
 
-Since all country and extension packages are maintained by different communities and depend on legal and cultural contexts, OpenFisca provides two packages aimed at demonstrating its capabilities independently: [`country-template`](https://github.com/openfisca/country-template/) and [`extension-template`](https://github.com/openfisca/extension-template/). They can be used to bootstrap new country or extension packages.
+Since all country and extension packages are maintained by different communities and depend on legal and cultural contexts, OpenFisca provides two templates aimed at demonstrating its capabilities independently:
+[`country-template`](https://github.com/openfisca/country-template/) 
+[`extension-template`](https://github.com/openfisca/extension-template/). 
 
+They can be bootstrapped with a new country or extension package.
+<!--Sentence unclear-->
 This documentation uses these packages throughout.

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -28,10 +28,6 @@ The Core also includes an optional [web API](openfisca-web-api/index.md), which 
 
 ## Templates
 
-Country and extension packages are maintained by different communities and depend on legal and cultural contexts. OpenFisca provides two templates aimed at demonstrating its capabilities independently:
+Country and extension packages are maintained by different communities and depend on their legal and cultural contexts. OpenFisca includes two neutral templates aimed at demonstrating their capabilities independently from these contexts: [`country-template`](https://github.com/openfisca/country-template/) and [`extension-template`](https://github.com/openfisca/extension-template/). These templates can also be used as boilerplate for creating a new country or extension package.
 
-- [`country-template`](https://github.com/openfisca/country-template/)
-- [`extension-template`](https://github.com/openfisca/extension-template/)
-
-They can be used as a start for creating a new country or extension package.
-This documentation uses these packages throughout.
+Code examples throughout the OpenFisca documentation use rules defined in both `country-template` and `extension-template`.

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -14,7 +14,6 @@ Country packages are what most users will interact with when using OpenFisca. Th
 
 Extensions add functionalities to a country package while maintaining situation description compatibility, by adding or redefining parameters and variables but not entities.
 
-<!--- Needs clarity here----->
 This architecture enables communities to maintain subsets of the rules of a country, especially those that are too specific to be of interest to the broader OpenFisca community of that country.
 
 > For example, [`openfisca-paris`](https://github.com/openfisca/openfisca-paris) extends `openfisca-france` with benefits specific to the town of Paris and is maintained by the Paris City Council.

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -12,16 +12,16 @@ Country packages are what most users will interact with when using OpenFisca. Th
 
 ## The Extensions Packages
 
-Extensions add functionalities to a country package by adding or redefining parameters and variables, but not entities while maintaining situation description compatibility.
+Extensions add functionalities to a country package while maintaining situation description compatibility, by adding or redefining parameters and variables but not entities.
 
 <!--- Needs clarity here----->
-This architecture enables sub-communities to maintain subsets of the rules of a country on which they have the authority, or are too specific to be of interest to the border OpenFisca community.
+This architecture enables communities to maintain subsets of the rules of a country, especially those that are too specific to be of interest to the broader OpenFisca community of that country.
 
 > For example, [`openfisca-paris`](https://github.com/openfisca/openfisca-paris) extends `openfisca-france` with benefits specific to the town of Paris and is maintained by the Paris City Council.
 
 ## The Core
 
-OpenFisca Core provides the API, domain-specific language (DSL) and testing tools. The country and extension packages are constructed based on the Core.
+OpenFisca Core provides the API, domain-specific language (DSL) and testing tools. The country and extension packages are constructed with the Core.
 
 The core defines the [Python API](openfisca-python-api/index.md) through which the country packages can be queried.
 

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -29,7 +29,7 @@ The Core also includes an optional [web API](openfisca-web-api/index.md), which 
 
 ## Templates
 
-Since all country and extension packages are maintained by different communities and depend on legal and cultural contexts, OpenFisca provides two templates aimed at demonstrating its capabilities independently:
+Country and extension packages are maintained by different communities and depend on legal and cultural contexts. OpenFisca provides two templates aimed at demonstrating its capabilities independently:
 [`country-template`](https://github.com/openfisca/country-template/) 
 [`extension-template`](https://github.com/openfisca/extension-template/). 
 

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -4,13 +4,13 @@ Depending on your goals, you will interact with one or several components of Ope
 
 [![OpenFisca architecture](https://cdn.rawgit.com/openfisca/openfisca-doc/master/source/static/img/architecture.svg)](https://github.com/openfisca/openfisca-doc/blob/master/source/static/img/architecture.svg)
 
-## The Country Packages
+## Country Packages
 
 Country packages are what most users will interact with when using OpenFisca. They model the rules of a jurisdiction by defining [Parameters](key-concepts/parameters.md), [Variables](key-concepts/variables.md) and [Entities](key-concepts/person,_entities,_role.md).
 
 > For example, [`openfisca-france`](https://github.com/openfisca/openfisca-france) models French law.
 
-## The Extensions Packages
+## Extensions Packages
 
 Extensions add functionalities to a country package while maintaining situation description compatibility, by adding or redefining parameters and variables but not entities.
 
@@ -19,7 +19,7 @@ This architecture enables communities to maintain subsets of the rules of a coun
 
 > For example, [`openfisca-paris`](https://github.com/openfisca/openfisca-paris) extends `openfisca-france` with benefits specific to the town of Paris and is maintained by the Paris City Council.
 
-## The Core
+## Core
 
 OpenFisca Core provides the API, domain-specific language (DSL) and testing tools. The country and extension packages are constructed with the Core.
 

--- a/source/architecture.md
+++ b/source/architecture.md
@@ -6,7 +6,7 @@ Depending on your goals, you will interact with one or several components of Ope
 
 ## The Country Packages
 
-Country packages are what most users will interact with when using OpenFisca. They model the rules of jurisdiction by defining [Parameters](key-concepts/parameters.md), [Variables](key-concepts/variables.md) and [Entities](key-concepts/person,_entities,_role.md).
+Country packages are what most users will interact with when using OpenFisca. They model the rules of a jurisdiction by defining [Parameters](key-concepts/parameters.md), [Variables](key-concepts/variables.md) and [Entities](key-concepts/person,_entities,_role.md).
 
 > For example, [`openfisca-france`](https://github.com/openfisca/openfisca-france) models French law.
 

--- a/source/coding-the-legislation/10_basic_example.md
+++ b/source/coding-the-legislation/10_basic_example.md
@@ -16,7 +16,7 @@ class flat_tax_on_salary(Variable):
         return salary * 0.25
 ```
 
-Let's explain in details the different parts of the code:
+Let's explain in detail the different parts of the code:
 
 ### The variable name
 
@@ -26,31 +26,31 @@ Let's explain in details the different parts of the code:
 
 All variables have a set of attributes.
 
-* `value_type` defines the type of the formula output. Possible types are the basic Python types.
+* The `value_type` defines the type of the formula output. Possible types are the basic Python types.
 Note however that OpenFisca uses NumPy to [run calculations vectorially](25_vectorial_computing.md),
 so the actual type of data may be slightly different from the built-in Python ones.
 Available types are:
   - `bool`: boolean
   - `date`: date
-  - `Enum`: discrete value (from an enumerable). [See details](20_input_variables.md) in the next section.
+  - `Enum`: discrete value (from an enumerable). [See details](20_input_variables.md) in the next section
   - `float`: float (Note that to reduce memory usage, float are stored on 32 bits using NumPy's `float32`)
   - `int`: integer
   - `str`: string
-* `entity` defines who or what group the variable concerns, e.g. individuals, households, families.
-* `definition_period` defines the period on which the variable is calculated. It can be `MONTH` (e.g. salary), `YEAR` (e.g. income taxes), or ETERNITY (e.g. date of birth).
-* `label` is a human friendly way to describe the variable.
-* `reference` is a list of relevant legislative reference for this variables (usually URLs the text of the law or another trustworthy source).
+* An `entity` defines who or what group the variable concerns, e.g. individuals, households, and families.
+* The `definition_period` defines the period on which the variable is calculated. It can be `MONTH` (e.g. salary), `YEAR` (e.g. income taxes), or ETERNITY (e.g. date of birth).
+* The `label` is a human-friendly way to describe the variable.
+* The `reference` is a list of relevant legislative references for a variable (usually URLs the text of the law or another trustworthy source).
 
 ### The formula
 
-* `def formula(person, period):` declares the formula that will be used to calculate the `flat_tax_on_salary` for a given `person` at a given `period`. Because `definition_period = MONTH`, `period` is constrained to be a month.
+* `def formula(person, period):` declares the formula that will be used to calculate the `flat_tax_on_salary` for a given `person` at a given `period`. Because `definition_period = MONTH` the `period` is constrained to be a month.
 * `salary = person('salary', period)` calculates the salary of the person, for the given month. This will, of course, work only if `salary` is another variable in the tax and benefit system.
 * `return salary * 0.25` returns the result for the given period.
 * [Dated Formulas](40_legislation_evolutions.md) have a start and/or an end date.
 
 ## Testing a formula
 
-To make sure that the formula you have just written works the way you expect, you have to test it. Tests about legislation are written in a [YAML syntax](writing_yaml_tests.md). The `flat_tax_on_salary` formula can for instance be tested with the following test file:
+To make sure that the formula you have just written works the way you expect, you have to test it. Tests about the legislation are written in a [YAML syntax](writing_yaml_tests.md). The `flat_tax_on_salary` formula can for instance be tested with the following test file:
 
 ```yaml
 - name: "Flax tax on salary - No income"
@@ -70,9 +70,9 @@ To make sure that the formula you have just written works the way you expect, yo
 
 You can check the [YAML tests documentation](writing_yaml_tests.md) to learn more about how to write YAML tests, and how to run them.
 
-## Example with legislation parameters
+## For Example with legislation parameters
 
-To access a common legislation parameter, a third parameter can be added to the function signature. The previous formulas could thus be rewritten:
+To access a common legislation parameter, a third parameter can be added to the function signature. The previous formulas could thus be rewritten as:
 
 ```py
 class flat_tax_on_salary(Variable):
@@ -87,4 +87,4 @@ class flat_tax_on_salary(Variable):
         return salary * parameters(period).taxes.salary.rate
 ```
 
-`parameters` is here a function that be be called for a given period, and returns the whole legislation parameters (in a hierarchical tree structure). You can get the parameter you are interested in by navigating this tree with the `.` notation.
+The `parameters` is a function that can be called for a given `period` that returns the whole legislation parameters (in a hierarchical tree structure). You can access the specific parameter you are interested in by navigating the tree structure with the  *.* notation.

--- a/source/coding-the-legislation/10_basic_example.md
+++ b/source/coding-the-legislation/10_basic_example.md
@@ -70,7 +70,7 @@ To make sure that the formula you have just written works the way you expect, yo
 
 You can check the [YAML tests documentation](writing_yaml_tests.md) to learn more about how to write YAML tests, and how to run them.
 
-## For example with legislation parameters
+## Example with legislation parameters
 
 To access a common legislation parameter, a third parameter can be added to the function signature. The previous formulas could thus be rewritten as:
 

--- a/source/coding-the-legislation/10_basic_example.md
+++ b/source/coding-the-legislation/10_basic_example.md
@@ -87,4 +87,4 @@ class flat_tax_on_salary(Variable):
         return salary * parameters(period).taxes.salary.rate
 ```
 
-The `parameters` is a function that can be called for a given `period` that returns the whole legislation parameters (in a hierarchical tree structure). You can access the specific parameter you are interested in by navigating the tree structure with the  *.* notation.
+The `parameters` is a function that can be called for a given period that returns the whole legislation parameters (in a hierarchical tree structure). You can access the specific parameter you are interested in by navigating the tree structure with the `.` notation.

--- a/source/coding-the-legislation/10_basic_example.md
+++ b/source/coding-the-legislation/10_basic_example.md
@@ -70,7 +70,7 @@ To make sure that the formula you have just written works the way you expect, yo
 
 You can check the [YAML tests documentation](writing_yaml_tests.md) to learn more about how to write YAML tests, and how to run them.
 
-## For Example with legislation parameters
+## For example with legislation parameters
 
 To access a common legislation parameter, a third parameter can be added to the function signature. The previous formulas could thus be rewritten as:
 

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -15,6 +15,7 @@ The following prefixes are used before channel names to increase discoverability
 - `share-` prefixed channels are newsrooms where everyone is encouraged to share their news, learnings and accomplishments.
 
 The following suffix conventions are used on tax and benefit system models by OpenFisca for better clarity:
+
 - Channels that centralize discussion around a specific tax and benefit system are suffixed with `-system`.
  _For example- `france-system`_.
 *Note: If the full name is too long for the Slack channel character limit, then a shortened version of the name is used.

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -1,4 +1,4 @@
-# <i class="fas fa-hands-helping"></i> To Find help
+# <i class="fas fa-hands-helping"></i> To find help
 
 ## Slack
 

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -1,28 +1,33 @@
-# <i class="fas fa-hands-helping"></i> Find help
+# <i class="fas fa-hands-helping"></i> To Find help
 
 ## Slack
 
 The OpenFisca community gathers around a [Slack space](https://openfisca.slack.com), which you can ask to join by sending a mail to [contact@openfisca.org](mailto:contact@openfisca.org?subject=Slack).
 
-This space provides both community and official support, and centralises all countries’ channels.
+This space provides community and official support and centralizes all countries’ channels.
 
-### Channels and naming conventions
+### Channels and Naming conventions
 
-In order to increase discoverability of channels and ease navigation, the following prefixes are used:
+The following prefixes are used before channel names to increase discoverability and ease of navigation:
 
-- `of-` channels are about quick discussions and requests for help on a technical module. To make decisions on changes to apply to these modules, we use GitHub issues and Pull Requests on dedicated repositories.
-- `share-` channels are newsrooms on which everyone is encouraged to share their news, learnings and accomplishments  :)
+- `of-` prefixed channels are about quick discussions and requests for help on a technical module. GitHub issues and Pull Requests on dedicated repositories are employed to make decisions on changes to apply to these modules if any.
 
-For tax and benefit systems models, the following conventions are applied:
+- `share-` prefixed channels are newsrooms where everyone is encouraged to share their news, learnings and accomplishments. :)
 
-- Channels that centralise discussions around a specific tax and benefit system are given the name of the distributed module, suffixed by `-system`. _For example: `france-system`_. If that full name is too long for the Slack channel character limit, then a shortened version of the name is used.
-- Channels that centralise discussions around extensions to tax and benefit systems are given that system’s module name, followed by `-ext-` and an identifier for that extension. _For example: `france-ext-paris`_.
-- System-specific group channels are campfires around which some specific organisations of contributors to a tax and benefit system gather. When a country becomes large enough, it often happens that several employers of contributors work concurrently on different parts of the system, and the main `-system` channel would become unreadable. These channels are called that system’s module name, followed by `-org-` and an identifier for that group. _For example: `france-org-gouv`_.
+The following suffix conventions are used on tax and benefit system models by OpenFisca for better clarity:
+- Channels that centralize discussion around a specific tax and benefit system are suffixed with `-system`.
+ _For example- `france-system`_.
+*Note: If the full name is too long for the Slack channel character limit, then a shortened version of the name is used.
+
+- Channels that centralize discussions around extensions to tax and benefit systems are given that system’s module name, followed by `-ext-` and an identifier for that extension.
+_For example- `france-ext-paris`_.
+
+- Channels for the system-specific groups are campfires around which some specific organizations of contributors to a tax and benefit system gather. When a country becomes large enough, it so often happens that several contributors work concurrently on different parts of the system, and the main `-system` channel becomes unreadable. These channels are then modified by the system’s module name, followed by `-org-` and an identifier for that group. _For example `france-org-gouv`_.
 
 ## Contact
 
-You can contact the OpenFisca maintainers through:
+Contact the OpenFisca maintainers through:
 
-- [GitHub](./contribute/guidelines.md#opening-issues) if you have any technical issue.
+- [GitHub](./contribute/guidelines.md#opening-issues) if you have any technical issues.
 - Twitter [@OpenFisca](https://twitter.com/OpenFisca) for general inquiries and feedback.
-- [email](mailto:contact@openfisca.org) for collaboration opportunities.
+- [Email](mailto:contact@openfisca.org) for collaboration opportunities.

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -12,7 +12,7 @@ The following prefixes are used before channel names to increase discoverability
 
 - `of-` prefixed channels are about quick discussions and requests for help on a technical module. GitHub issues and Pull Requests on dedicated repositories are employed to make decisions on changes to apply to these modules if any.
 
-- `share-` prefixed channels are newsrooms where everyone is encouraged to share their news, learnings and accomplishments. :)
+- `share-` prefixed channels are newsrooms where everyone is encouraged to share their news, learnings and accomplishments.
 
 The following suffix conventions are used on tax and benefit system models by OpenFisca for better clarity:
 - Channels that centralize discussion around a specific tax and benefit system are suffixed with `-system`.

--- a/source/find-help.md
+++ b/source/find-help.md
@@ -4,7 +4,7 @@
 
 The OpenFisca community gathers around a [Slack space](https://openfisca.slack.com), which you can ask to join by sending a mail to [contact@openfisca.org](mailto:contact@openfisca.org?subject=Slack).
 
-This space provides community and official support and centralizes all countries’ channels.
+This space provides community and official support and centralises all countries’ channels.
 
 ### Channels and Naming conventions
 

--- a/source/index.md
+++ b/source/index.md
@@ -1,16 +1,23 @@
 # <i class="fas fa-home"></i> Before you start
 
-[OpenFisca](https://openfisca.org) is an open source engine to write rules as code.
+## What is OpenFisca
 
-Describe your tax and benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
+[OpenFisca](https://openfisca.org) is an open-source engine to write rules as code.
+
+Describe your tax and benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results!
 
 ## Who uses OpenFisca
 
-* **Economists and lawmakers**: calculate the effects of policies. Combine them with survey data to simulate the impact of a reform on a given government’s budget and on a population’s standard of living.
-* **Developers and companies**: easily create web applications based on simulation results, thanks to the [web API](openfisca-web-api/index.md). You can build a great variety of services by coding formulas, hosting your own instance and building your own extensions.
-* **Public administrations**: stop building your own micro-simulation software and tax & benefit calculators. Instead, contribute to OpenFisca, collaborate with other administrations and reduce costs to the taxpayer.
+* **Economists and lawmakers**: 
+Economists and lawmakers make use of OpenFisca to calculate the effects of policies. By combining them with survey data to simulate the impact of reform on a given government’s budget and a population’s standard of living.
 
-## Path to using OpenFisca
+* **Developers and companies**:
+Developers and companies use Openfisca to effortlessly create web applications based on simulation results with the help of the OpenFisca [web API](openfisca-web-api/index.md). You can build a great significant variety of services by coding formulas, hosting your instances and building your extensions.
+
+* **Public administrations**: 
+Stop building your micro-simulation software and tax & benefit calculators from scratch. Join OpenFisca, contribute to OpenFisca, collaborate with other administrations and reduce costs paid by the taxpayers.
+
+## Ways to use OpenFisca
 
 ### 1 - Use an available country package or roll your own
 
@@ -20,7 +27,7 @@ To get started, you can:
 * [Build a new tax and benefit system](coding-the-legislation/bootstrapping_a_new_country_package.md) if it doesn’t exist already.
 * [Contribute](contribute/index.md) to an existing system by adding or improving elements of the legislation.
 
-Then, you will turn legal code into OpenFisca code, which is a subset of the Python programming language with many helpful tools:
+With many helpful OpenFisca tools, you can turn legal code into OpenFisca code which is a subset of the Python programming language:
 
 * First, identify some legislation that can be expressed as an arithmetic operation.
 * Then, translate them into [formulas, variables, parameters, etc.](coding-the-legislation/index.md)
@@ -29,31 +36,42 @@ Then, you will turn legal code into OpenFisca code, which is a subset of the Pyt
 
 ### 2 - Identify the input data you need
 
-With OpenFisca, you can calculate the effect of legislation on a single situation or on a whole population by running a “[simulation](simulate/index.md)”. Since the data you need depends on what you’re trying to calculate, OpenFisca doesn’t provide any data up front.
+With OpenFisca, you can calculate the effect of legislation on a single situation or a whole population by running a [simulation](simulate/index.md). Since the data you need depends on what you are trying to calculate, OpenFisca does not offer any data upfront.
 
-Do you want to help users find their eligibility for a social benefit in your country? Build a user interface asking them for their income and demographic information in order to provide them with an answer (do not forget to comply with GDPR!).
+The following could be your use case to use OpenFisca:
 
-Are you trying to assess the impact of a new housing tax on behalf of the OECD? Find your government's open survey data to simulate the impact of that tax reform on the poorest 20% of a country.
+Do you want to help users find their eligibility for a social benefit in your country? Then, use OpenFisca to build a user interface asking them for their income and demographic information and provide them with an answer! (Do not forget to comply with GDPR!).
 
-### 3 - Run simulations
+Are you trying to assess the impact of a new housing tax on behalf of the OECD? Find your government's open survey data and use it with the OpenFisca to simulate the effect of that tax reform on the poorest 20% of a country.
 
-There are two ways to calculate the effect of the rules modelled in a country package on the given input data with OpenFisca:
+### 3 - Run Simulations
 
-* If you have a background in web development or want to build a web application with the results of your simulation, you’ll want to use the [web API](openfisca-web-api/index.md).
-* If you have a background in datascience, want to use large datasets, or want to dynamically apply changes to the system, you’ll rather use the [Python API](openfisca-python-api/index.md).
+With OpenFisca there are two ways to calculate the effect of the rules modelled in a country package on a given input data:
 
-The output of this simulation will be either Python objects or JSON. Many other libraries will then help you represent these results graphically ([plot.ly](https://plot.ly) for instance will get you those nice charts you’ve seen elsewhere).
+*With the results of your simulation, efficiently build a web application. Using the [web API](openfisca-web-api/index.md).
+**Using the  [Python API](openfisca-python-api/index.md) data scientist can utilize a large dataset to perform a survey or apply changes to your system dynamically.
+
+The output of this simulation will be either in Python objects or JSON. To represent these results in a graphical or visualized format you can make use of python libraries for ex:([plot.ly](https://plot.ly) for instance will get you those nice charts you’ve seen elsewhere).
 
 Please make sure you read our [license](license.md) before publishing results based on OpenFisca.
 
 ## Things OpenFisca won’t do for you
 
-* **Behaviour-based analysis.** OpenFisca is a static micro-simulation model, so it will provide you with results “as-of-tomorrow”, without taking retroactive effects or “elasticity” into account (e.g. a new tax bracket won’t affect consumption).
-* **Human decisions.** This might seem obvious, but is worth reiterating: any process that includes human judgement can not be automated. Human decisions can be modelled as input variables, but OpenFisca does not aim at doing machine learning on past decisions for probabilistic results, for example.
-* **Zero effort modelling.** While our community is strong and you can often benefit from its shared efforts, OpenFisca is contributive: if the legislation you need is not described yet, you’re the best person to add it (take a look at our [contribution guidelines](contribute/index.md) first).
-* **Magic legislation parsing.** OpenFisca is a framework for humans to collaborate on translating rules into code. It does not ingest lawyer speak and automatically produce developer speak. Regulation is ambiguous and needs human interpretation before being codified.
-* **Textual comparisons.** OpenFisca shines in dealing with numbers: enumerated values are a later addition, and support for serving and testing string values is not built in.
+* **Behaviour-based analysis.**
+<!--Needs more clarity here--->
+OpenFisca is a static micro-simulation model, so it will provide you with results “as of tomorrow”, without taking retroactive effects or “elasticity” into account (e.g. a new tax bracket won’t affect consumption).
 
-## Feeling lost?
+* **Human decisions.** 
+This might seem obvious, but it is worth reiterating: any process that includes human judgement can not be completely automated. Human decisions can be modelled as input variables, but OpenFisca does not aim at doing machine learning on past decisions for probabilistic results, for example.
+* **Zero effort modelling.** 
+While our community is strong and you can often benefit from its shared efforts, OpenFisca is contributive: if the legislation you need is not described yet, you’re the best person to add it (take a look at our [contribution guidelines](contribute/index.md) first).
 
-You’re not sure if OpenFisca can suit your project? [Drop us a line](mailto:contact@openfisca.org?subject=Contact%20from%20doc) and we’ll tell you!
+* **Magical legislation parsing.** 
+OpenFisca is a framework for humans to collaborate on translating rules into code. It does not ingest lawyer speak(abstruse jargon of lawyers) and automatically produces developer speak(terminologies used by developers). Regulations are ambiguous and need human interpretation before being codified.
+
+* **Textual comparisons.**
+OpenFisca shines in dealing with numbers: enumerated values are a later addition. Hence support for serving and testing with *string values* is not built-in.
+
+## Feeling lost 😟?
+
+Not sure how OpenFisca can suit your project? [Drop us a line](mailto:contact@openfisca.org?subject=Contact%20from%20doc), and we will guide you!

--- a/source/index.md
+++ b/source/index.md
@@ -48,8 +48,8 @@ Are you trying to assess the impact of a new housing tax on behalf of the OECD? 
 
 With OpenFisca there are two ways to calculate the effect of the rules modelled in a country package on a given input data:
 
-*With the results of your simulation, efficiently build a web application. Using the [web API](openfisca-web-api/index.md).
-**Using the  [Python API](openfisca-python-api/index.md) data scientist can utilize a large dataset to perform a survey or apply changes to your system dynamically.
+* If you have a background in web development or want to build a web application with the results of your simulation, you’ll want to use the [web API](openfisca-web-api/index.md).
+ * If you have a background in datascience, want to use large datasets, or want to dynamically apply changes to the system, you’ll rather use the [Python API](openfisca-python-api/index.md).
 
 The output of this simulation will be either Python objects or JSON. To represent these results in a graphical format, you can make use of Python libraries such as [plot.ly](https://plot.ly).
 

--- a/source/index.md
+++ b/source/index.md
@@ -73,6 +73,6 @@ OpenFisca is a framework for humans to collaborate on translating rules into cod
 
 OpenFisca shines in dealing with numbers: enumerated values are a later addition, and support for serving and testing with string values is not built-in.
 
-## Feeling lost 😟?
+## Feeling lost?
 
 Not sure how OpenFisca can suit your project? [Drop us a line](mailto:contact@openfisca.org?subject=Contact%20from%20doc), and we will guide you!

--- a/source/index.md
+++ b/source/index.md
@@ -42,7 +42,7 @@ The following could be your use case to use OpenFisca:
 
 Do you want to help users find their eligibility for a social benefit in your country? Then, use OpenFisca to build a user interface asking them for their income and demographic information and provide them with an answer! (Do not forget to comply with GDPR!).
 
-Are you trying to assess the impact of a new housing tax on behalf of the OECD? Find your government's open survey data and use it with the OpenFisca to simulate the effect of that tax reform on the poorest 20% of a country.
+Are you trying to assess the impact of a new housing tax on behalf of the OECD? Find your government's open survey data and use it with OpenFisca to simulate the effect of that tax reform on the poorest 20% of a country.
 
 ### 3 - Run Simulations
 
@@ -51,7 +51,7 @@ With OpenFisca there are two ways to calculate the effect of the rules modelled 
 *With the results of your simulation, efficiently build a web application. Using the [web API](openfisca-web-api/index.md).
 **Using the  [Python API](openfisca-python-api/index.md) data scientist can utilize a large dataset to perform a survey or apply changes to your system dynamically.
 
-The output of this simulation will be either in Python objects or JSON. To represent these results in a graphical or visualized format you can make use of python libraries for ex:([plot.ly](https://plot.ly) for instance will get you those nice charts you’ve seen elsewhere).
+The output of this simulation will be either Python objects or JSON. To represent these results in a graphical format, you can make use of Python libraries such as [plot.ly](https://plot.ly).
 
 Please make sure you read our [license](license.md) before publishing results based on OpenFisca.
 
@@ -70,7 +70,8 @@ While our community is strong and you can often benefit from its shared efforts,
 OpenFisca is a framework for humans to collaborate on translating rules into code. It does not ingest lawyer speak(abstruse jargon of lawyers) and automatically produces developer speak(terminologies used by developers). Regulations are ambiguous and need human interpretation before being codified.
 
 * **Textual comparisons.**
-OpenFisca shines in dealing with numbers: enumerated values are a later addition. Hence support for serving and testing with *string values* is not built-in.
+
+OpenFisca shines in dealing with numbers: enumerated values are a later addition, and support for serving and testing with string values is not built-in.
 
 ## Feeling lost 😟?
 

--- a/source/index.md
+++ b/source/index.md
@@ -17,7 +17,7 @@ Developers and companies use Openfisca to effortlessly create web applications b
 * **Public administrations**: 
 Stop building your micro-simulation software and tax & benefit calculators from scratch. Join OpenFisca, contribute to OpenFisca, collaborate with other administrations and reduce costs paid by the taxpayers.
 
-## Ways to use OpenFisca
+## Way to use OpenFisca
 
 ### 1 - Use an available country package or roll your own
 
@@ -57,7 +57,7 @@ Please make sure you read our [license](license.md) before publishing results ba
 
 ## Things OpenFisca won’t do for you
 
-* **Behaviour-based analysis.**
+### Behaviour-based analysis
 <!--Needs more clarity here--->
 OpenFisca is a static micro-simulation model, so it will provide you with results “as of tomorrow”, without taking retroactive effects or “elasticity” into account (e.g. a new tax bracket won’t affect consumption).
 

--- a/source/index.md
+++ b/source/index.md
@@ -8,13 +8,13 @@ Describe your tax and benefit system, provide a situation as input (i.e income),
 
 ## Who uses OpenFisca
 
-* **Economists and lawmakers**: 
+* **Economists and lawmakers**:
 Economists and lawmakers make use of OpenFisca to calculate the effects of policies. By combining them with survey data to simulate the impact of reform on a given government’s budget and a population’s standard of living.
 
 * **Developers and companies**:
 Developers and companies use Openfisca to effortlessly create web applications based on simulation results with the help of the OpenFisca [web API](openfisca-web-api/index.md). You can build a great significant variety of services by coding formulas, hosting your instances and building your extensions.
 
-* **Public administrations**: 
+* **Public administrations**:
 Stop building your micro-simulation software and tax & benefit calculators from scratch. Join OpenFisca, contribute to OpenFisca, collaborate with other administrations and reduce costs paid by the taxpayers.
 
 ## Way to use OpenFisca
@@ -27,7 +27,7 @@ To get started, you can:
 * [Build a new tax and benefit system](coding-the-legislation/bootstrapping_a_new_country_package.md) if it doesn’t exist already.
 * [Contribute](contribute/index.md) to an existing system by adding or improving elements of the legislation.
 
-With many helpful OpenFisca tools, you can turn legal code into OpenFisca code which is a subset of the Python programming language:
+Then, you will make legal code executable by writing it in the OpenFisca [DSL](https://en.wikipedia.org/wiki/Domain-specific_language), which is a subset of the Python programming language with dedicated functions and tools specifically targeted at modelling rules:
 
 * First, identify some legislation that can be expressed as an arithmetic operation.
 * Then, translate them into [formulas, variables, parameters, etc.](coding-the-legislation/index.md)
@@ -55,23 +55,27 @@ The output of this simulation will be either Python objects or JSON. To represen
 
 Please make sure you read our [license](license.md) before publishing results based on OpenFisca.
 
-## Things OpenFisca won’t do for you
+## What OpenFisca will not do for you
 
 ### Behaviour-based analysis
-<!--Needs more clarity here--->
-OpenFisca is a static micro-simulation model, so it will provide you with results “as of tomorrow”, without taking retroactive effects or “elasticity” into account (e.g. a new tax bracket won’t affect consumption).
 
-* **Human decisions.** 
+OpenFisca is a _static_ micro-simulation model, so it will provide you with results “as of tomorrow”, without taking retroactive effects or “elasticity” into account (e.g. new taxes will not impact purchasing behaviour).
+
+### Human decisions
+
 This might seem obvious, but it is worth reiterating: any process that includes human judgement can not be completely automated. Human decisions can be modelled as input variables, but OpenFisca does not aim at doing machine learning on past decisions for probabilistic results, for example.
-* **Zero effort modelling.** 
+
+### Zero effort modelling
+
 While our community is strong and you can often benefit from its shared efforts, OpenFisca is contributive: if the legislation you need is not described yet, you’re the best person to add it (take a look at our [contribution guidelines](contribute/index.md) first).
 
-* **Magical legislation parsing.** 
-OpenFisca is a framework for humans to collaborate on translating rules into code. It does not ingest lawyer speak(abstruse jargon of lawyers) and automatically produces developer speak(terminologies used by developers). Regulations are ambiguous and need human interpretation before being codified.
+### Magical legislation parsing
 
-* **Textual comparisons.**
+OpenFisca is a framework for humans to collaborate on translating rules into code. It does not ingest lawyer speak and automatically produce developer speak. Regulations are ambiguous and need human interpretation before being codified.
 
-OpenFisca shines in dealing with numbers: enumerated values are a later addition, and support for serving and testing with string values is not built-in.
+### Textual comparisons
+
+OpenFisca shines in dealing with numbers: enumerated values are a later addition, and support for string values is not built-in.
 
 ## Feeling lost?
 

--- a/source/index.md
+++ b/source/index.md
@@ -49,7 +49,7 @@ Are you trying to assess the impact of a new housing tax on behalf of the OECD? 
 With OpenFisca there are two ways to calculate the effect of the rules modelled in a country package on a given input data:
 
 * If you have a background in web development or want to build a web application with the results of your simulation, you’ll want to use the [web API](openfisca-web-api/index.md).
- * If you have a background in datascience, want to use large datasets, or want to dynamically apply changes to the system, you’ll rather use the [Python API](openfisca-python-api/index.md).
+* If you have a background in datascience, want to use large datasets, or want to dynamically apply changes to the system, you’ll rather use the [Python API](openfisca-python-api/index.md).
 
 The output of this simulation will be either Python objects or JSON. To represent these results in a graphical format, you can make use of Python libraries such as [plot.ly](https://plot.ly).
 

--- a/source/license.md
+++ b/source/license.md
@@ -1,10 +1,14 @@
 # <i class="fab fa-creative-commons"></i> License
 
-OpenFisca is free software made available under the [AGPL license](https://choosealicense.com/licenses/agpl-3.0/). This means that you are free to use, install and modify it, and that you have to contribute your changes back to the community. This is the only way a contributive digital common can be sustainable, so we are very happy that you take part in this shared effort!
+OpenFisca is a free software made available under the [AGPL license](https://choosealicense.com/licenses/agpl-3.0/). This means that you are free to use, install and modify it with the promise to contribute back your changes to the community. This is the only way a contributive digital common can be made sustainable.
+Any contributions are welcome as long as they abide by our contribution guidelines. We are happy to have you here at the OpenFisca community.
+
+## OpenFisca as:
 
 ## Computation results
+<!--Can be rephrased to be welcoming and appreciative. -->
+If you provide results based on OpenFisca usage, crediting the project would be very welcome in order to increase its visibility and contributor base. More people means more maintenance and more upgrades!
 
-If you provide results based on OpenFisca usage, crediting the project would be very welcome in order to increase its visibility and to increase its contributor base. More people means more maintenance and more upgrades!
 
 The following HTML snippet can be used to credit OpenFisca in your articles and publications:
 
@@ -26,9 +30,9 @@ The following HTML snippet can be used to credit OpenFisca in your articles and 
 
 ## Hosting an API instance
 
-If you provide a service that uses OpenFisca, either bundled in a program or serving it over the network, be it directly or wrapped through another API layer, you have to credit OpenFisca, give a link to its source code and license.
+If you provide a service that uses OpenFisca, either bundled in a program or serving it over the network, be it directly or wrapped through another API layer, you have to credit OpenFisca, by providing a link to its source code and license.
 
-The following HTML snippet can be used to credit OpenFisca, for example in your footer or “about” page.
+The following HTML snippet can be used to credit OpenFisca, for example by placing it in your footer or “about” page.
 Please make sure to update the destination of the source code link if you use a modified version!
 
 ### English
@@ -53,8 +57,8 @@ Please make sure to update the destination of the source code link if you use a 
 
 ## Changes
 
-If you modify or extend OpenFisca, you are [legally required](https://choosealicense.com/licenses/agpl-3.0/) to make those changes available to the community. The easiest way to do it is to publish your fork of the core package, and of any country package, extension or reform, on a source hosting platform such as GitHub, and to notify the core team of this publication.
+If you modify or extend OpenFisca, you are [legally required](https://choosealicense.com/licenses/agpl-3.0/) to make those changes available to the community. The easiest way to do it is to publish your fork of the core package, and any country package, extension or reform, on a source hosting platform such as GitHub, and to notify the core team of this publication.
 
-You can read [this analysis](https://softwareengineering.stackexchange.com/questions/107883/agpl-what-you-can-do-and-what-you-cant/314908/) to get more insight on what you can and can't do with APGL licensed software.
+You can read [this analysis](https://softwareengineering.stackexchange.com/questions/107883/agpl-what-you-can-do-and-what-you-cant/314908/) to get more insight into what you can and can't do with APGL-licensed software.
 
-If you see opportunities in developing services/business/tools on top of OpenFisca but are concerned with the AGPL3 license implications, please [open an issue](https://github.com/openfisca/openfisca-core/issues/new) to have a public discussion on the topic.
+If you see opportunities in developing services/businesses/tools on top of OpenFisca but are concerned with the AGPL3 license implications, please [open an issue](https://github.com/openfisca/openfisca-core/issues/new) to have a public discussion on the topic.

--- a/source/license.md
+++ b/source/license.md
@@ -1,7 +1,7 @@
 # <i class="fab fa-creative-commons"></i> License
 
 OpenFisca is a free software made available under the [AGPL license](https://choosealicense.com/licenses/agpl-3.0/). This means that you are free to use, install and modify it with the promise to contribute back your changes to the community. This is the only way a contributive digital common can be made sustainable.
-Any contributions are welcome as long as they abide by our contribution guidelines. We are happy to have you here at the OpenFisca community.
+All contributions are welcome as long as they abide by our contribution guidelines. We are happy to have you here in the OpenFisca community.
 
 ## OpenFisca as:
 

--- a/source/license.md
+++ b/source/license.md
@@ -3,8 +3,6 @@
 OpenFisca is a free software made available under the [AGPL license](https://choosealicense.com/licenses/agpl-3.0/). This means that you are free to use, install and modify it with the promise to contribute back your changes to the community. This is the only way a contributive digital common can be made sustainable.
 All contributions are welcome as long as they abide by our contribution guidelines. We are happy to have you here in the OpenFisca community.
 
-## OpenFisca as:
-
 ## Computation results
 <!--Can be rephrased to be welcoming and appreciative. -->
 If you provide results based on OpenFisca usage, crediting the project would be very welcome to increase its visibility and contributor base. More people means more maintenance and more upgrades.

--- a/source/license.md
+++ b/source/license.md
@@ -7,7 +7,6 @@ All contributions are welcome as long as they abide by our contribution guidelin
 
 If you provide results based on OpenFisca usage, crediting the project would be very welcome to increase its visibility and contributor base. More people means more maintenance and more upgrades.
 
-
 The following HTML snippet can be used to credit OpenFisca in your articles and publications:
 
 ### English

--- a/source/license.md
+++ b/source/license.md
@@ -4,7 +4,7 @@ OpenFisca is a free software made available under the [AGPL license](https://cho
 All contributions are welcome as long as they abide by our contribution guidelines. We are happy to have you here in the OpenFisca community.
 
 ## Computation results
-<!--Can be rephrased to be welcoming and appreciative. -->
+
 If you provide results based on OpenFisca usage, crediting the project would be very welcome to increase its visibility and contributor base. More people means more maintenance and more upgrades.
 
 

--- a/source/license.md
+++ b/source/license.md
@@ -7,7 +7,7 @@ All contributions are welcome as long as they abide by our contribution guidelin
 
 ## Computation results
 <!--Can be rephrased to be welcoming and appreciative. -->
-If you provide results based on OpenFisca usage, crediting the project would be very welcome in order to increase its visibility and contributor base. More people means more maintenance and more upgrades!
+If you provide results based on OpenFisca usage, crediting the project would be very welcome to increase its visibility and contributor base. More people means more maintenance and more upgrades.
 
 
 The following HTML snippet can be used to credit OpenFisca in your articles and publications:

--- a/source/manifest-history.md
+++ b/source/manifest-history.md
@@ -2,18 +2,18 @@
 
 The development of OpenFisca began in May 2011 at the [<abbr title="Centre d'analyse stratégique">CAS</abbr>](http://www.strategie.gouv.fr/) (renamed France Stratégie / Commissariat général à la stratégie et à la prospective in April 2013) with the support of the [<abbr title="Institut d'économie publique">IDEP</abbr>](https://www.idep-fr.org/).
 
-OpenFisca was originally developed as a desktop application using the [Qt](http://www.qt.io/) library with a Python API. This original source code was released under a free software license in November 2011.
+OpenFisca was originally developed as a desktop application using the [Qt](http://www.qt.io/) library with a Python API. This source code was released under a free software license in November 2011.
 
-In the early 2014, [Etalab](https://www.etalab.gouv.fr/) started using OpenFisca and soon became a major contributor. It then decided to:
+In early 2014, [Etalab](https://www.etalab.gouv.fr/) started using OpenFisca and soon became a major contributor. It then decided to:
 
-- separate the computing engine from its desktop user interface;
-- offer a web API in addition to the Python API;
-- demonstrate the value of the web API by developing sample applications including a web interface to simulate personal cases;
-- offer a public access to this web API;
-- stop the development of the [Qt version](https://github.com/openfisca/openfisca-qt).
+- Separate the computing engine from its desktop user interface;
+- Offer a web API in addition to the Python API;
+- Demonstrate the value of the web API by developing sample applications including a web interface to simulate personal cases;
+- Offer public access to this web API;
+- Stop the development of the [Qt version](https://github.com/openfisca/openfisca-qt).
 
 The core was improved extensively by [Etalab](https://www.etalab.gouv.fr/), while the French model was being improved and updated by the [<abbr title="Commissariat général à la stratégie et à la prospective">CGSP</abbr>](http://www.strategie.gouv.fr/) with the help of the [<abbr title="Institut d'économie publique">IDEP</abbr>](https://www.idep-fr.org/) and the [<abbr title="Institut des politiques publiques">IPP</abbr>](http://www.ipp.eu/), soon to be joined by the French [State Startups incubator](https://beta.gouv.fr) which used and extended the model for digital public services purposes.
 
-The 2016 <abbr title="OpenGovernment Partnership">OGP</abbr> Paris summit saw a demonstration that a small team could model the base of a tax and benefit system from scratch under 36 hours, when the [Sénégal](https://github.com/openfisca/openfisca-senegal-ui) income revenue tax was modelled and made usable with a web UI during the OGP hackathon, winning the team the first prize.
+The 2016 <abbr title="OpenGovernment Partnership">OGP</abbr> Paris summit saw a demonstration that a small team could model the base of a tax and benefit system from scratch in under 36 hours, when the [Sénégal](https://github.com/openfisca/openfisca-senegal-ui) income revenue tax was modelled and made usable with a web UI during the OGP hackathon, winning the team the first prize.
 
-This led in 2017 to a joint effort from Etalab and beta.gouv.fr with a major focus on stability, ease of contribution and reusability. This lead to the full rewrite of the documentation, the opening of [openfisca.org](https://openfisca.org) to replace openfisca.fr, and the addition of new contributors from other French agencies, as well as international reusers with [Barcelona](https://github.com/jvalduvieco/openfisca-barcelona) joining [Tunisia](https://github.com/openfisca/openfisca-tunisia).
+This led, in 2017, to a joint effort from Etalab and beta.gouv.fr with a major focus to provide stability, ease of contribution and reusability. This led to the full rewrite of the documentation, the opening of [openfisca.org](https://openfisca.org) to replace openfisca.fr, and the addition of new contributors from other French agencies, as well as international re-users with [Barcelona](https://github.com/jvalduvieco/openfisca-barcelona) joining [Tunisia](https://github.com/openfisca/openfisca-tunisia).

--- a/source/simulate/analyse-simulation.md
+++ b/source/simulate/analyse-simulation.md
@@ -1,6 +1,6 @@
 # Analysing or debugging a simulation
 
-When running a simulation with the Python API, you might want to understand how the result was calculated and what intermediate variables and parameters have been taken into account.
+When simulating with the Python API, you might want to understand how the result was calculated and what intermediate variables and parameters have been taken into account.
 
 > To trace a simulation calculation with the web API, please see [/trace endpoint documentation](../openfisca-web-api/trace-simulation.md).
 
@@ -71,11 +71,11 @@ The previous code example would give us this output:
     rent<2011-01> >> [300.   0.]
 ```
 
-The `rent` variable is indented to the right relative to `housing_allowance`. This says that `housing_allowance` variable called the `rent` calculation. It was called on the same period, '2011-01'. As the [rent variable](https://demo.openfisca.org/legislation/rent)'s value was an input value given by our `TEST_CASE`, it was returned to `housing_allowance`. Then, as the [housing_allowance variable](https://demo.openfisca.org/legislation/housing_allowance) has a valid formula on '2011-01', it used the `rent` value to calculate its amount for its two households (`h1` and `h2`): `[75.  0.]`
+The `rent` variable is indented to the right relative to `housing_allowance`. This means that `housing_allowance` variable called the `rent` calculation. It was called on the same period, '2011-01'. As the [rent variable](https://demo.openfisca.org/legislation/rent)'s value was an input value given by our `TEST_CASE`, it was returned to `housing_allowance`. Then, as the [housing_allowance variable](https://demo.openfisca.org/legislation/housing_allowance) has a valid formula on '2011-01', it used the `rent` value to calculate its amount for its two households (`h1` and `h2`): `[75.  0.]`
 
-Thus, on the left side of the double chevrons, you can read the trace from top to bottom to see the dependencies between the variables. And, on the right side, you can read it from bottom to top to see how the simulation result is built.
+Thus, on the left side of the double chevrons, you can read the trace from top to bottom to see the dependencies between the variables. And on the right side, you can read it from bottom to top to see how the simulation result is built.
 
-Likewise if you are calculating this `housing_allowance` on a large population, you will be able to check your calculation results with aggregated outputs. To do so, you can add the `aggregate=True` option as follows:
+Likewise, if you are calculating `housing_allowance` on a large population you will be able to check your calculation results with aggregated outputs. To do so, you can add the `aggregate=True` option as follows:
 
 ```py
 simulation.tracer.print_computation_log(aggregate=True)

--- a/source/simulate/index.md
+++ b/source/simulate/index.md
@@ -11,11 +11,14 @@ profile-simulation
 
 To calculate Tax and Benefit System variables on people's situations, you need to create and run a new _Simulation_.
 
-OpenFisca will work the same if there is one person, seven, or seven million in the modeled situation.
+OpenFisca will work the same if there is one person, seven, or seven million in the modelled situation.
 
 > Technically speaking, OpenFisca uses [vector computing](../coding-the-legislation/25_vectorial_computing.md) via the [NumPy](http://www.numpy.org/) package for performance reasons.
 
-Nevertheless, you won't have the same experience defining those various situations sizes and linking them to your simulation. So, multiple options could be used to describe this information:
+<!-- The below text is confusing and needs clarification-->
+Nevertheless, you won't have the same experience defining those various situation sizes and linking them to your simulation. So, multiple options could be used to describe this information:
+
+<!---The below text is confusing here and needs clear wording-->
 
 - either [test cases](./run-simulation.md#test-cases): you simulate the legislation for a small number of persons,
 - or [bulk data](./run-simulation.md#data): you provide a population (survey with aggregated data, CSV files with bulk data, etc.) on which you want to apply the legislation.


### PR DESCRIPTION
I have edited the following files for typos and spelling mistakes etc. so far.
1.  README.md
2. source/architecture.md
3. source/coding-the-legislation/10_basic_example.md
4. source/find-help.md
5. source/index.md
6. source/license.md
7. source/manifest-history.md
8. source/simulate/analyse-simulation.md
9. source/simulate/index.md

For editing, I am using Grammarly's help. The following are the metrics I am using while editing:
1. Clarity of text from a  general users perspective to provide a continues flow of thought,
2. Delivery of sentence to be informative and descriptive,
3. Correctness of sentences

Keeping the above in mind I have reworded certain sentences and paragraphs to make them more clear.
And have added Comments before the lines that I was unable to correctly understand.

- [x] Also made a correction for the image path of the logo to fix #278 

source/_templates/sidebar.html

Please review and let me know if any changes are required.😊.
